### PR TITLE
ci: add Ruff enforcement via pre-commit and GitHub Actions (+ uv)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv python install 3.10
+      - run: uv sync --extra all
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,6 @@ line-length = 120
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 ignore = ["E731", "F403", "F405"]
+
+[tool.uv]
+# Install with: uv sync --extra all


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` to enforce the Ruff lint/format config already defined in `pyproject.toml`
- Add `.github/workflows/lint.yml` to run Ruff checks on every push and PR
- Add `uv` as the recommended install method (via `astral-sh/setup-uv` in CI)

## Motivation

`pyproject.toml` already has a complete `[tool.ruff]` config (E/F/I rules, 120-char line length) but nothing enforces it — no pre-commit hooks, no CI. This PR wires that up without changing any existing configuration or code style rules.

## What's not included

- No new lint rules beyond what's already selected (`E`, `F`, `I`)
- No type checking (ty/mypy) — out of scope for now
- No test runner — left for a follow-up

## Testing

Ran `ruff check .` and `ruff format --check .` locally against the current codebase — no violations.