### PR TITLE
feat: add Hermes integration, skill tracking, diagnostic CLI, and doc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Runtime data
+records/
+evolve_history.jsonl
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Environment
+.env
+*.env.local

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # ✨ SkillClaw: Let Skills Evolve Collectively with Agentic Evolver ✨
 
-<h3>Evolve distributed AI agent clusters in production — just talk.<br>Experience auto-distilled. Skills keep growing. Collective intelligence shared in real time.</h3>
+<h3>AI agent skills that evolve from every real interaction — just talk.<br>Across sessions, agents, devices, and users. Experience compounds. Skills keep growing.</h3>
 
 | 🚀 Quick Install | 💬 Just Chat | 🔌 Broad Compatibility | 🧬 Collective Skill Evolution |
 |:-:|:-:|:-:|:-:|
@@ -45,7 +45,7 @@
 </tr>
 <tr>
 <td>🧬 <b>Collective Skill Evolution</b></td>
-<td>Real-world experience from multiple users and agents is distilled into reusable Skills, shared via the cloud, enabling continuous evolution across the entire agent cluster.</td>
+<td>Skills evolve from every session, every agent, every context. Solo or team — the loop is the same. Every experience compounds.</td>
 </tr>
 </table>
 
@@ -53,17 +53,61 @@
 
 <div align="center">
 
-## From Experience Silos to Collective Evolution
+## What SkillClaw Brings to One Hermes User
+
+</div>
+
+Been using Hermes for a while — is your skill library still a mess? Duplicates, outdated ones, half-baked ones all piled together like an unsorted loot box. The problem isn't that Hermes doesn't learn enough — it's that nobody helps it **digest**.
+
+**SkillClaw is built for this.** Auto-evolve, auto-deduplicate, auto-improve quality. It won't change how you work or interrupt your flow — it just quietly rewrites your agent's growth curve.
+
+SkillClaw doesn't make Hermes learn more — it makes everything Hermes has learned actually count.
+
+<div align="center">
+
+<img src="assets/two_loops.svg" alt="Two Loops: Hermes task-time loop + SkillClaw post-task evolution loop" width="860">
+
+</div>
+
+That's just one user's story. One user can also run multiple agents or use multiple devices — SkillClaw unifies them all:
+
+<div align="center">
+
+### Multiple agents? One unified skill library.
+
+<img src="assets/multiplier_effect.svg" alt="The Multiplier Effect: Multiple Hermes agents sharing skills through SkillClaw" width="860">
+
+</div>
+
+Running multiple Hermes agents for different tasks? Without SkillClaw, each builds its own isolated skill silo. With SkillClaw, skills are **merged, deduplicated, and cross-pollinated** into a unified library, then distributed back to all agents. Your Frontend agent's React patterns make the Backend agent's API design better — and vice versa.
+
+<div align="center">
+
+### Multiple devices? Skills follow you, not your machine.
+
+<img src="assets/cross_context.svg" alt="Seamless Context: Home, School, and Company Hermes instances unified by SkillClaw" width="860">
+
+</div>
+
+Same user, different machines. Your Home Hermes learns React; your School Hermes learns ML; your Work Hermes learns K8s. Without SkillClaw, each starts from scratch. With it, **skills unify across all environments** — every Hermes instance benefits from every other's experience, regardless of where you are.
+
+---
+
+<div align="center">
+
+## Collective Skill Evolution
+
+</div>
+
+Everything above is what one user gets. Now scale it up: when you join a shared group, **every team member's real-world experience feeds into the same evolution loop**. User A debugs a database issue — the skill evolves. User B, C, D benefit instantly without ever hitting the same problem. N users, one Skill, continuous evolution.
+
+<div align="center">
 
 <img src="assets/shift_contrast.svg" alt="The Shift: From Experience Silos to Collective Evolution" width="860">
 
 <br>
 
-## How a Skill Evolves
-
-<img src="assets/skill_evolution.svg" alt="Skill Evolution Flow" width="860">
-
-**N users, one Skill, continuous evolution.** Every conversation compounds. Every user contributes.
+<img src="assets/skill_evolution.svg" alt="Skill Evolution Flow: How a skill evolves across multiple users" width="860">
 
 </div>
 
@@ -89,13 +133,13 @@
 
 ## Overview
 
-SkillClaw makes LLM agents progressively better by **evolving reusable skills** from real session data and sharing them across a group of agents.
+SkillClaw makes LLM agents progressively better by **evolving reusable skills** from real session data. A single user already benefits — skills are automatically deduplicated, improved, and verified across sessions. Scale up when you're ready: multiple agents, multiple devices, or multiple users can all feed the same evolution loop.
 
 The system has two components:
 
-1. **Client Proxy** — A local API proxy (`/v1/chat/completions`, `/v1/messages`) that intercepts agent requests, records session artifacts, and syncs skills with shared storage.
+1. **Client Proxy** — A local API proxy (`/v1/chat/completions`, `/v1/messages`) that intercepts agent requests, records session artifacts, and manages your local skill library. This is all you need to get started.
 
-2. **Evolve Server** (`evolve_server`) — A single evolve service that reads session data from shared storage, evolves or creates skills, and writes them back. It supports two engines:
+2. **Evolve Server** (`evolve_server`) — An optional service that reads session data from shared storage, evolves or creates skills, and writes them back. Add it when you want automatic evolution or team-wide sharing. It supports two engines:
    - `workflow`: fixed 3-stage LLM pipeline (Summarize → Aggregate → Execute)
    - `agent`: OpenClaw-driven agent workspace with direct skill editing
 
@@ -105,13 +149,12 @@ Both components share the same storage layer (Alibaba OSS / S3 / local filesyste
 
 ## Deployment Model
 
-Think of SkillClaw as "per-user client, per-group evolver":
+Start with just the client. Add the server when you need it.
 
-1. Every user runs a local `skillclaw` client proxy on their own machine.
-2. One shared group usually runs one `skillclaw-evolve-server`.
-3. The client side and server side only meet through shared storage (`local`, `oss`, or `s3`).
+1. **Single user + auto-evolution**: Install the client proxy, then add an evolve server on the same machine (or anywhere that can reach your storage) to automatically refine skills in the background.
+2. **Team / shared group**: Point multiple clients at the same shared storage and run one `skillclaw-evolve-server` for the group. Everyone's experience feeds the same evolution loop.
 
-This separation is the key beginner mental model:
+The client and server only meet through shared storage (`local`, `oss`, or `s3`). This means:
 
 - If you only want to use SkillClaw yourself, install the client first. You can add an evolve server later.
 - If you want to join an existing team, you still install only the client. You do not run the evolve server unless you are operating the shared group.
@@ -165,7 +208,7 @@ The setup wizard prompts for the provider, model, local skills directory, PRM se
 For a minimal first run:
 
 - choose `none` for the CLI agent if you do not want SkillClaw to auto-configure an external agent yet
-- local skills at `~/.skillclaw/skills`
+- local skills at `~/.skillclaw/skills` for the generic setup path; if you choose Hermes, the default local library becomes `~/.hermes/skills`
 - disable shared storage if you only want to use the local proxy first
 - enable local shared storage only if you want to add the evolve server later on the same machine, and use a dedicated root such as `~/.skillclaw/local-share`
 - disable PRM if you want the cheapest first pass
@@ -193,6 +236,8 @@ If you already use Hermes, the client-side path is:
 2. Run `skillclaw setup` and choose `hermes` for `CLI agent to configure`.
 3. Keep `Proxy model name exposed to agents` as `skillclaw-model` unless you have a specific reason to change it.
 4. Start SkillClaw. On startup, SkillClaw rewrites `~/.hermes/config.yaml` to point Hermes at the local proxy.
+5. Hermes uses `~/.hermes/skills` as the default local skill library. SkillClaw prepares that directory automatically and copies in any missing legacy skills from `~/.skillclaw/skills`.
+6. If you want to inspect or undo the integration, use `skillclaw doctor hermes` and `skillclaw restore hermes`.
 
 Minimal verification:
 
@@ -200,6 +245,15 @@ Minimal verification:
 skillclaw start --daemon
 hermes chat -Q -m skillclaw-model -q "Reply with exactly HERMES_SKILLCLAW_OK and nothing else."
 ```
+
+Optional diagnostics:
+
+```bash
+skillclaw doctor hermes
+skillclaw restore hermes
+```
+
+`skillclaw doctor hermes` reports whether Hermes is pointed at the local proxy, whether the Hermes skills directory exists, whether legacy skills are still present, and that session boundaries still fall back to proxy-side heuristics unless Hermes sends explicit session headers.
 
 ### Path B: Join an existing shared group
 

--- a/assets/README_ZH.md
+++ b/assets/README_ZH.md
@@ -4,7 +4,7 @@
 
 # ✨ SkillClaw: Let Skills Evolve Collectively with Agentic Evolver ✨
 
-<h3>让分布式 AI Agent 群体在真实部署中持续进化 —— 只需对话。<br>经验自动提取，技能持续生长，集体智慧即时共享。</h3>
+<h3>让 AI Agent 技能从每一次真实交互中自动进化 —— 只需对话。<br>跨会话、跨 Agent、跨设备、跨用户，经验持续累积，技能群体进化。</h3>
 
 | 🚀 安装快捷 | 💬 只需对话 | 🔌 广泛兼容 | 🧬 技能群体进化 |
 |:-:|:-:|:-:|:-:|
@@ -44,7 +44,7 @@
 </tr>
 <tr>
 <td>🧬 <b>技能群体进化</b></td>
-<td>多用户、多 Agent 的实战经验自动提炼为可复用 Skill，通过云端共享，让整个 Agent 集群持续进化。</td>
+<td>技能从每一次对话、每一个 Agent、每一个场景中进化。单人或团队，进化闭环完全一致。每一份经验都在累积。</td>
 </tr>
 </table>
 
@@ -52,17 +52,61 @@
 
 <div align="center">
 
-### 从经验孤岛到群体进化
+## SkillClaw 给一个 Hermes 用户带来了什么
+
+</div>
+
+Hermes 用久了，技能库是不是一锅乱炖？重复的、过时的、半成品的全挤在一起，像没人整理的掉落箱。问题不是学得不够多，而是没人帮它"消化"。
+
+**SkillClaw 就是干这个的。** 自动进化、自动去重、自动提质。不改变你的使用方式，不打断你的节奏，只是悄悄改写 Agent 的成长曲线。
+
+SkillClaw 不是让 Hermes 学更多，而是让它学到的一切，真正变成战斗力。
+
+<div align="center">
+
+<img src="./two_loops.svg" alt="双循环：Hermes 任务期循环 + SkillClaw 任务后进化循环" width="860">
+
+</div>
+
+这只是一个人的故事。一个用户也可以跑多个 Agent、用多台设备，SkillClaw 把它们全部统一：
+
+<div align="center">
+
+### 多个 Agent？统一技能库。
+
+<img src="./multiplier_effect.svg" alt="乘数效应：多个 Hermes Agent 通过 SkillClaw 共享技能" width="860">
+
+</div>
+
+同时运行多个 Hermes Agent 做不同任务？没有 SkillClaw，每个 Agent 都在建自己的技能孤岛。有了 SkillClaw，技能会被**合并、去重、交叉融合**成一个统一技能库，再分发给所有 Agent。前端 Agent 的 React 技能让后端 Agent 的 API 设计更好——反之亦然。
+
+<div align="center">
+
+### 多台设备？技能跟着你走，不跟机器走。
+
+<img src="./cross_context.svg" alt="无缝场景：家里、学校、公司的 Hermes 通过 SkillClaw 统一" width="860">
+
+</div>
+
+同一个人，不同机器。你家里的 Hermes 学了 React，学校的 Hermes 学了 ML，公司的 Hermes 学了 K8s。没有 SkillClaw，每台机器都从零开始。有了它，**技能跨环境统一**——每个 Hermes 实例都受益于其他所有环境的经验，不管你在哪里。
+
+---
+
+<div align="center">
+
+## 技能群体进化
+
+</div>
+
+以上都是一个用户能获得的。现在放大：加入共享群组后，**每个成员的实战经验都汇入同一个进化循环**。用户 A 调试了一个数据库问题——技能进化了。用户 B、C、D 立刻受益，根本不用自己再踩一遍。N 个用户，一个 Skill，持续进化。
+
+<div align="center">
 
 <img src="./shift_contrast.svg" alt="从经验孤岛到群体进化" width="860">
 
 <br>
 
-### 四个人的经验，一个 Skill 的进化
-
-<img src="./skill_evolution.svg" alt="技能进化流程" width="860">
-
-**N 个用户，一个 Skill，持续进化。** Every conversation compounds. Every user contributes.
+<img src="./skill_evolution.svg" alt="技能进化流程：一个技能如何在多个用户之间进化" width="860">
 
 </div>
 
@@ -88,13 +132,13 @@
 
 ## 项目概览
 
-SkillClaw 通过从真实会话数据中**演化可复用技能**并在一组 Agent 之间共享，让 LLM Agent 持续变强。
+SkillClaw 通过从真实会话数据中**演化可复用技能**，让 LLM Agent 持续变强。一个人用就已经有效——技能会在每次会话间自动去重、提质、验证。准备好了就往上扩：多个 Agent、多台设备、多个用户，都能汇入同一个进化循环。
 
 系统由两个部分组成：
 
-1. **Client Proxy** — 本地 API 代理（`/v1/chat/completions`、`/v1/messages`），负责拦截 Agent 请求、记录会话产物，并与共享存储同步技能。
+1. **Client Proxy** — 本地 API 代理（`/v1/chat/completions`、`/v1/messages`），负责拦截 Agent 请求、记录会话产物，并管理你的本地技能库。只装这个就能用起来。
 
-2. **Evolve Server**（`evolve_server`）— 统一的技能演化服务，从共享存储读取会话数据，演化或创建技能，再写回存储。它支持两种 engine：
+2. **Evolve Server**（`evolve_server`）— 可选的技能演化服务，从共享存储读取会话数据，演化或创建技能，再写回存储。当你需要自动演化或团队共享时再加。它支持两种 engine：
    - `workflow`：固定三阶段 LLM 流程（Summarize → Aggregate → Execute）
    - `agent`：基于 OpenClaw 的自主 agent 工作区，直接编辑技能文件
 
@@ -104,13 +148,12 @@ SkillClaw 通过从真实会话数据中**演化可复用技能**并在一组 Ag
 
 ## 部署模型
 
-可以把 SkillClaw 理解成"每个用户一个 Client，每个群组一个 Evolver"：
+先装 Client，需要时再加 Server。
 
-1. 每个用户都在自己的机器上运行本地 `skillclaw` Client Proxy。
-2. 每个共享群组通常只运行一个 `skillclaw-evolve-server`。
-3. 用户侧和服务器侧只通过共享存储（`local`、`oss`、`s3`）发生连接。
+1. **单用户 + 自动演化**：装好 Client Proxy，再在同一台机器（或任何能访问存储的地方）加一个 Evolve Server，让技能在后台自动精炼。
+2. **团队 / 共享群组**：多个 Client 指向同一个共享存储，群组运行一个 `skillclaw-evolve-server`。所有人的经验汇入同一个进化循环。
 
-这个拆分是最适合初学者的理解方式：
+Client 和 Server 只通过共享存储（`local`、`oss`、`s3`）发生连接。这意味着：
 
 - 如果你只是自己用，先装 Client 就够了，后面再决定要不要加 Evolver。
 - 如果你是加入一个现有群组，你仍然只需要安装 Client，不需要在自己机器上跑 Evolver。
@@ -164,7 +207,7 @@ skillclaw setup
 第一次最小化验证时，推荐这样选：
 
 - `CLI agent` 选 `none`，先不要自动改外部 agent 配置
-- `skills` 目录保持默认值 `~/.skillclaw/skills`
+- `skills` 目录保持默认值 `~/.skillclaw/skills`；如果你选了 Hermes，默认技能库会变成 `~/.hermes/skills`
 - 如果你只是想先验证代理能不能正常用，可以先关闭 shared storage
 - 如果你后面想在同一台机器上继续跑本地 evolver 闭环，就把 shared storage 打开并选 `local` backend，例如 `~/.skillclaw/local-share`
 - 如果你想先把成本压到最低，可以先关闭 PRM
@@ -192,6 +235,8 @@ curl "http://127.0.0.1:${PROXY_PORT}/healthz"
 2. 运行 `skillclaw setup`，在 `CLI agent to configure` 里选择 `hermes`。
 3. `Proxy model name exposed to agents` 保持 `skillclaw-model`，除非你明确知道自己为什么要改它。
 4. 启动 SkillClaw。启动时，SkillClaw 会自动改写 `~/.hermes/config.yaml`，把 Hermes 指到本地代理。
+5. Hermes 默认使用 `~/.hermes/skills` 作为本地技能库。SkillClaw 会自动准备好该目录，并把 `~/.skillclaw/skills` 中遗留的旧技能复制过来。
+6. 如果你想检查或撤销集成，使用 `skillclaw doctor hermes` 和 `skillclaw restore hermes`。
 
 最小验证命令：
 
@@ -199,6 +244,15 @@ curl "http://127.0.0.1:${PROXY_PORT}/healthz"
 skillclaw start --daemon
 hermes chat -Q -m skillclaw-model -q "Reply with exactly HERMES_SKILLCLAW_OK and nothing else."
 ```
+
+可选诊断命令：
+
+```bash
+skillclaw doctor hermes
+skillclaw restore hermes
+```
+
+`skillclaw doctor hermes` 会检查 Hermes 是否指向了本地代理、Hermes skills 目录是否存在、旧技能是否还在、以及会话边界是否仍回退到代理侧的启发式策略（除非 Hermes 发送了显式的 session header）。
 
 ### 路径 B：加入一个已有的共享群组
 

--- a/assets/cross_context.svg
+++ b/assets/cross_context.svg
@@ -1,0 +1,178 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 790" width="960" height="790">
+  <defs>
+    <linearGradient id="titleGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#D44040"/>
+      <stop offset="100%" stop-color="#4A90D4"/>
+    </linearGradient>
+    <linearGradient id="hubGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#EBF4FF"/>
+      <stop offset="100%" stop-color="#D4E8FA"/>
+    </linearGradient>
+    <linearGradient id="dividerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="20%" stop-color="#F0CDCB"/>
+      <stop offset="50%" stop-color="#E2E8F0"/>
+      <stop offset="80%" stop-color="#B8D4F0"/>
+      <stop offset="100%" stop-color="#FFFFFF"/>
+    </linearGradient>
+    <filter id="hubGlow">
+      <feGaussianBlur stdDeviation="6" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <style>
+    @keyframes pulse{0%,100%{opacity:1}50%{opacity:.55}}
+    @keyframes corePulse{0%,100%{opacity:.85}50%{opacity:1}}
+    @keyframes flowIn{0%{stroke-dashoffset:20}100%{stroke-dashoffset:0}}
+    @keyframes flowOut{0%{stroke-dashoffset:-20}100%{stroke-dashoffset:0}}
+    @keyframes flowRight{0%{stroke-dashoffset:16}100%{stroke-dashoffset:0}}
+    @keyframes ringRotate{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+    .pulse{animation:pulse 2.5s ease-in-out infinite}
+    .core-pulse{animation:corePulse 3s ease-in-out infinite}
+    .flow-in{stroke-dasharray:6 4;animation:flowIn .8s linear infinite}
+    .flow-out{stroke-dasharray:6 4;animation:flowOut .8s linear infinite}
+    .flow-right{stroke-dasharray:5 3;animation:flowRight .6s linear infinite}
+    .ring-spin{transform-origin:480px 400px;animation:ringRotate 20s linear infinite}
+  </style>
+
+  <rect width="960" height="790" rx="18" fill="#FFFFFF"/>
+  <rect width="960" height="790" rx="18" fill="none" stroke="#E2E8F0" stroke-width="1"/>
+
+  <!-- TITLE -->
+  <text x="480" y="32" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="800" letter-spacing="5" fill="url(#titleGrad)">SEAMLESS CONTEXT</text>
+  <text x="480" y="58" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="22" font-weight="900" fill="#0F172A">One User, Multiple Hermes, Unified Skills</text>
+  <!-- user avatar -->
+  <circle cx="350" cy="80" r="10" fill="#EDE9FE" stroke="#8B5CF6" stroke-width="1.2"/>
+  <circle cx="350" cy="77" r="3.5" fill="#7C3AED"/>
+  <path d="M343,86 Q350,91 357,86" fill="none" stroke="#7C3AED" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="366" y="85" font-family="Inter,-apple-system,sans-serif" font-size="13" font-weight="600" fill="#6D28D9">You &#x2014; same person, different places</text>
+  <rect x="80" y="96" width="800" height="1.5" rx="1" fill="url(#dividerGrad)"/>
+
+  <!-- Legend (top-right corner, out of the way) -->
+  <g transform="translate(710,76)">
+    <line x1="0" y1="0" x2="20" y2="0" stroke="#D44040" stroke-width="2.5" class="flow-in"/>
+    <polygon points="24,-3 24,3 28,0" fill="#D44040"/>
+    <text x="34" y="4" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="600" fill="#B5302A">In</text>
+    <line x1="60" y1="0" x2="80" y2="0" stroke="#4A90D4" stroke-width="2.5" class="flow-out"/>
+    <polygon points="84,-3 84,3 88,0" fill="#4A90D4"/>
+    <text x="94" y="4" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="600" fill="#2B6FAC">Back</text>
+  </g>
+
+  <!-- ===== ARROWS (behind everything) ===== -->
+  <line x1="472" y1="238" x2="472" y2="288" stroke="#D44040" stroke-width="2" class="flow-in"/>
+  <polygon points="467.8,288.0 476.2,288.0 472.0,294.0" fill="#D44040"/>
+  <line x1="488" y1="288" x2="488" y2="238" stroke="#4A90D4" stroke-width="2" class="flow-out" style="animation-delay:.2s"/>
+  <polygon points="492.2,238.0 483.8,238.0 488.0,232.0" fill="#4A90D4"/>
+
+  <line x1="206" y1="598" x2="392" y2="470" stroke="#D44040" stroke-width="2" class="flow-in"/>
+  <polygon points="394.6,473.5 389.8,466.5 397.1,466.6" fill="#D44040"/>
+  <line x1="383" y1="457" x2="197" y2="585" stroke="#4A90D4" stroke-width="2" class="flow-out" style="animation-delay:.2s"/>
+  <polygon points="194.2,581.5 198.9,588.4 191.6,588.3" fill="#4A90D4"/>
+
+  <line x1="763" y1="585" x2="577" y2="457" stroke="#D44040" stroke-width="2" class="flow-in"/>
+  <polygon points="579.2,453.3 574.5,460.3 571.9,453.4" fill="#D44040"/>
+  <line x1="568" y1="470" x2="754" y2="598" stroke="#4A90D4" stroke-width="2" class="flow-out" style="animation-delay:.2s"/>
+  <polygon points="752.0,601.6 756.8,594.6 759.4,601.5" fill="#4A90D4"/>
+
+  <!-- ===== 3 SCENE CARDS ===== -->
+  <rect x="370" y="110" width="220" height="120" rx="12" fill="#FEF7F7" stroke="#F0CDCB" stroke-width="1.2"/>
+  <g transform="translate(382,118) scale(0.85)">
+    <path d="M16,2 L2,14 L6,14 L6,26 L26,26 L26,14 L30,14 Z" fill="#FCEAEA" stroke="#D44040" stroke-width="1.5" stroke-linejoin="round"/>
+    <rect x="12" y="16" width="8" height="10" rx="1" fill="#F0CDCB" stroke="#D44040" stroke-width="1"/>
+  </g>
+  <text x="412" y="134" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="800" fill="#B5302A">Home</text>
+  <text x="412" y="150" font-family="Inter,-apple-system,sans-serif" font-size="11" fill="#C0392B">Personal projects</text>
+  <g transform="translate(382,158)"><circle cx="8" cy="8" r="8" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1"/><path d="M9,2 L7,8 L8,8 L7,14 L11,6 L9,6 Z" fill="#D44040"/></g>
+  <text x="404" y="170" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#B5302A">Hermes</text>
+  <rect x="382" y="180" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.0s"/>
+  <text x="406" y="193" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">React</text>
+  <rect x="434" y="180" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.2s"/>
+  <text x="458" y="193" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">CSS</text>
+  <rect x="486" y="180" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.4s"/>
+  <text x="510" y="193" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">Node.js</text>
+  <rect x="538" y="180" width="30" height="18" rx="4" fill="#D4E8FA" stroke="#C2D9F0" stroke-width="1"/>
+  <text x="553" y="193" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="800" fill="#4A90D4">+6</text>
+  <text x="382" y="216" font-family="Inter,-apple-system,sans-serif" font-size="10" fill="#3A7CBD">+ Python, LaTeX, ML, Docker, K8s, SQL</text>
+
+  <rect x="35" y="570" width="220" height="120" rx="12" fill="#FEF7F7" stroke="#F0CDCB" stroke-width="1.2"/>
+  <g transform="translate(47,578) scale(0.85)">
+    <path d="M16,6 L0,14 L16,22 L32,14 Z" fill="#FCEAEA" stroke="#D44040" stroke-width="1.5" stroke-linejoin="round"/>
+    <path d="M8,16 L8,24 Q16,30 24,24 L24,16" fill="none" stroke="#D44040" stroke-width="1.5"/>
+    <line x1="30" y1="14" x2="30" y2="26" stroke="#D44040" stroke-width="1.5" stroke-linecap="round"/>
+    <circle cx="30" cy="27" r="1.5" fill="#D44040"/>
+  </g>
+  <text x="77" y="594" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="800" fill="#B5302A">School</text>
+  <text x="77" y="610" font-family="Inter,-apple-system,sans-serif" font-size="11" fill="#C0392B">Academic &amp; research</text>
+  <g transform="translate(47,618)"><circle cx="8" cy="8" r="8" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1"/><path d="M9,2 L7,8 L8,8 L7,14 L11,6 L9,6 Z" fill="#D44040"/></g>
+  <text x="69" y="630" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#B5302A">Hermes</text>
+  <rect x="47" y="640" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.0s"/>
+  <text x="71" y="653" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">Python</text>
+  <rect x="99" y="640" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.2s"/>
+  <text x="123" y="653" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">LaTeX</text>
+  <rect x="151" y="640" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.4s"/>
+  <text x="175" y="653" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">ML/AI</text>
+  <rect x="203" y="640" width="30" height="18" rx="4" fill="#D4E8FA" stroke="#C2D9F0" stroke-width="1"/>
+  <text x="218" y="653" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="800" fill="#4A90D4">+6</text>
+  <text x="47" y="676" font-family="Inter,-apple-system,sans-serif" font-size="10" fill="#3A7CBD">+ React, CSS, Node, Docker, K8s, SQL</text>
+
+  <rect x="705" y="570" width="220" height="120" rx="12" fill="#FEF7F7" stroke="#F0CDCB" stroke-width="1.2"/>
+  <g transform="translate(717,578) scale(0.85)">
+    <rect x="2" y="8" width="28" height="20" rx="3" fill="#FCEAEA" stroke="#D44040" stroke-width="1.5"/>
+    <path d="M10,8 L10,4 Q10,2 12,2 L20,2 Q22,2 22,4 L22,8" fill="none" stroke="#D44040" stroke-width="1.5"/>
+    <line x1="2" y1="18" x2="30" y2="18" stroke="#D44040" stroke-width="1"/>
+  </g>
+  <text x="747" y="594" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="800" fill="#B5302A">Company</text>
+  <text x="747" y="610" font-family="Inter,-apple-system,sans-serif" font-size="11" fill="#C0392B">Work &amp; production</text>
+  <g transform="translate(717,618)"><circle cx="8" cy="8" r="8" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1"/><path d="M9,2 L7,8 L8,8 L7,14 L11,6 L9,6 Z" fill="#D44040"/></g>
+  <text x="739" y="630" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#B5302A">Hermes</text>
+  <rect x="717" y="640" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.0s"/>
+  <text x="741" y="653" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">Docker</text>
+  <rect x="769" y="640" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.2s"/>
+  <text x="793" y="653" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">K8s</text>
+  <rect x="821" y="640" width="48" height="18" rx="4" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:0.4s"/>
+  <text x="845" y="653" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="700" fill="#D44040">SQL</text>
+  <rect x="873" y="640" width="30" height="18" rx="4" fill="#D4E8FA" stroke="#C2D9F0" stroke-width="1"/>
+  <text x="888" y="653" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="10" font-weight="800" fill="#4A90D4">+6</text>
+  <text x="717" y="676" font-family="Inter,-apple-system,sans-serif" font-size="10" fill="#3A7CBD">+ React, CSS, Node, Python, LaTeX, ML</text>
+
+  <!-- ===== CENTRAL HUB ===== -->
+  <circle cx="480" cy="400" r="118" fill="none" stroke="#B8D4F0" stroke-width="1" opacity=".25" class="core-pulse"/>
+  <circle cx="480" cy="400" r="109" fill="none" stroke="#C2D9F0" stroke-width="1" stroke-dasharray="6 10" class="ring-spin"/>
+  <circle cx="480" cy="400" r="100" fill="url(#hubGrad)" stroke="#B8D4F0" stroke-width="2" filter="url(#hubGlow)"/>
+
+  <!-- Shield icon -->
+  <g transform="translate(464,325)">
+    <path d="M16,0 L4,6 L4,16 C4,26 10,32 16,36 C22,32 28,26 28,16 L28,6 Z" fill="none" stroke="#4A90D4" stroke-width="2" stroke-linejoin="round"/>
+    <path d="M11,17 L14,21 L22,11" fill="none" stroke="#4A90D4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="480" y="372" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="22" font-weight="800" fill="#1D4E7E">SKILLCLAW</text>
+
+  <!-- 4-step flow: horizontal row -->
+  <rect x="390" y="388" width="54" height="24" rx="6" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1"/>
+  <text x="417" y="406" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="12" font-weight="800" fill="#2B6FAC">Filter</text>
+
+  <line x1="444" y1="400" x2="454" y2="400" stroke="#6AAAD8" stroke-width="2" class="flow-right"/>
+  <polygon points="454,396 462,400 454,404" fill="#6AAAD8"/>
+
+  <rect x="462" y="388" width="66" height="24" rx="6" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1"/>
+  <text x="495" y="406" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="12" font-weight="800" fill="#2B6FAC">Improve</text>
+
+  <!-- second row -->
+  <rect x="390" y="420" width="54" height="24" rx="6" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1"/>
+  <text x="417" y="438" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="12" font-weight="800" fill="#2B6FAC">Verify</text>
+
+  <line x1="444" y1="432" x2="454" y2="432" stroke="#6AAAD8" stroke-width="2" class="flow-right" style="animation-delay:.15s"/>
+  <polygon points="454,428 462,432 454,436" fill="#6AAAD8"/>
+
+  <rect x="462" y="420" width="66" height="24" rx="6" fill="#C2D9F0" stroke="#4A90D4" stroke-width="1.2"/>
+  <text x="495" y="438" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="12" font-weight="800" fill="#1D4E7E">Solidify</text>
+
+  <!-- Library label below hub -->
+  <text x="480" y="522" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="700" fill="#1D4E7E">Unified Skill Library</text>
+  <text x="480" y="540" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="13" fill="#3A7CBD">Best of all contexts &#xB7; Evolved &#xB7; Verified</text>
+
+  <!-- KEY INSIGHT (bottom, no overlap) -->
+  <rect x="130" y="740" width="700" height="34" rx="10" fill="#F5F9FF" stroke="#C2D9F0" stroke-width="1.5"/>
+  <text x="480" y="762" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="800" fill="#2B6FAC">Home skills make Work better &#xB7; Work skills make School faster &#xB7; All grow together</text>
+
+</svg>

--- a/assets/multiplier_effect.svg
+++ b/assets/multiplier_effect.svg
@@ -1,0 +1,224 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 780" width="960" height="780">
+  <defs>
+    <linearGradient id="titleGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#D44040"/>
+      <stop offset="100%" stop-color="#4A90D4"/>
+    </linearGradient>
+    <linearGradient id="dividerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="20%" stop-color="#F0CDCB"/>
+      <stop offset="50%" stop-color="#E2E8F0"/>
+      <stop offset="80%" stop-color="#B8D4F0"/>
+      <stop offset="100%" stop-color="#FFFFFF"/>
+    </linearGradient>
+    <linearGradient id="libGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#D4E8FA"/>
+      <stop offset="100%" stop-color="#C2D9F0"/>
+    </linearGradient>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <style>
+    @keyframes pulse{0%,100%{opacity:1}50%{opacity:.55}}
+    @keyframes corePulse{0%,100%{opacity:.85}50%{opacity:1}}
+    @keyframes flowDown{0%{stroke-dashoffset:20}100%{stroke-dashoffset:0}}
+    @keyframes flowRight{0%{stroke-dashoffset:16}100%{stroke-dashoffset:0}}
+    .pulse{animation:pulse 2.5s ease-in-out infinite}
+    .core-pulse{animation:corePulse 3s ease-in-out infinite}
+    .flow-down{stroke-dasharray:6 4;animation:flowDown .8s linear infinite}
+    .flow-right{stroke-dasharray:5 3;animation:flowRight .6s linear infinite}
+  </style>
+
+  <rect width="960" height="780" rx="18" fill="#FFFFFF"/>
+  <rect width="960" height="780" rx="18" fill="none" stroke="#E2E8F0" stroke-width="1"/>
+
+  <!-- TITLE -->
+  <text x="480" y="42" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="18" font-weight="800" letter-spacing="6" fill="url(#titleGrad)">THE MULTIPLIER EFFECT</text>
+  <text x="480" y="76" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="26" font-weight="900" fill="#0F172A">Multiple Hermes, One Collective Intelligence</text>
+  <rect x="50" y="92" width="860" height="2" rx="1" fill="url(#dividerGrad)"/>
+
+  <!-- ===== TOP ROW: 4 HERMES AGENTS ===== -->
+  <!-- Agent A -->
+  <rect x="50" y="112" width="200" height="100" rx="12" fill="#FEF7F7" stroke="#F0CDCB" stroke-width="1.2"/>
+  <g transform="translate(66, 120)"><circle cx="12" cy="12" r="12" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1.2"/><path d="M13,4 L9,12 L12,12 L11,20 L15,10 L12,10 Z" fill="#D44040"/></g>
+  <text x="96" y="138" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="800" fill="#B5302A">Hermes A</text>
+  <text x="66" y="158" font-family="Inter,-apple-system,sans-serif" font-size="14" fill="#C0392B">Frontend Dev</text>
+  <rect x="66" y="172" width="168" height="28" rx="6" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse"/>
+  <rect x="76" y="179" width="50" height="10" rx="3" fill="#FCEAEA"/>
+  <text x="101" y="188" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="8" font-weight="700" fill="#D44040">skill</text>
+  <rect x="132" y="182" width="80" height="4" rx="2" fill="#F0CDCB"/>
+
+  <!-- Agent B -->
+  <rect x="270" y="112" width="200" height="100" rx="12" fill="#FEF7F7" stroke="#F0CDCB" stroke-width="1.2"/>
+  <g transform="translate(286, 120)"><circle cx="12" cy="12" r="12" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1.2"/><path d="M13,4 L9,12 L12,12 L11,20 L15,10 L12,10 Z" fill="#D44040"/></g>
+  <text x="316" y="138" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="800" fill="#B5302A">Hermes B</text>
+  <text x="286" y="158" font-family="Inter,-apple-system,sans-serif" font-size="14" fill="#C0392B">Backend Dev</text>
+  <rect x="286" y="172" width="168" height="28" rx="6" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:.3s"/>
+  <rect x="296" y="179" width="50" height="10" rx="3" fill="#FCEAEA"/>
+  <text x="321" y="188" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="8" font-weight="700" fill="#D44040">skill</text>
+  <rect x="352" y="182" width="80" height="4" rx="2" fill="#F0CDCB"/>
+
+  <!-- Agent C -->
+  <rect x="490" y="112" width="200" height="100" rx="12" fill="#FEF7F7" stroke="#F0CDCB" stroke-width="1.2"/>
+  <g transform="translate(506, 120)"><circle cx="12" cy="12" r="12" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1.2"/><path d="M13,4 L9,12 L12,12 L11,20 L15,10 L12,10 Z" fill="#D44040"/></g>
+  <text x="536" y="138" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="800" fill="#B5302A">Hermes C</text>
+  <text x="506" y="158" font-family="Inter,-apple-system,sans-serif" font-size="14" fill="#C0392B">DevOps</text>
+  <rect x="506" y="172" width="168" height="28" rx="6" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:.6s"/>
+  <rect x="516" y="179" width="50" height="10" rx="3" fill="#FCEAEA"/>
+  <text x="541" y="188" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="8" font-weight="700" fill="#D44040">skill</text>
+  <rect x="572" y="182" width="80" height="4" rx="2" fill="#F0CDCB"/>
+
+  <!-- Agent D -->
+  <rect x="710" y="112" width="200" height="100" rx="12" fill="#FEF7F7" stroke="#F0CDCB" stroke-width="1.2"/>
+  <g transform="translate(726, 120)"><circle cx="12" cy="12" r="12" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1.2"/><path d="M13,4 L9,12 L12,12 L11,20 L15,10 L12,10 Z" fill="#D44040"/></g>
+  <text x="756" y="138" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="800" fill="#B5302A">Hermes D</text>
+  <text x="726" y="158" font-family="Inter,-apple-system,sans-serif" font-size="14" fill="#C0392B">Data Analysis</text>
+  <rect x="726" y="172" width="168" height="28" rx="6" fill="#FFF" stroke="#E8A0A0" stroke-width="1" class="pulse" style="animation-delay:.9s"/>
+  <rect x="736" y="179" width="50" height="10" rx="3" fill="#FCEAEA"/>
+  <text x="761" y="188" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="8" font-weight="700" fill="#D44040">skill</text>
+  <rect x="792" y="182" width="80" height="4" rx="2" fill="#F0CDCB"/>
+
+  <!-- ===== TOP CONVERGING ARROWS: agents -> SkillClaw ===== -->
+  <!-- 4 short lines down from each agent -->
+  <line x1="150" y1="212" x2="150" y2="230" stroke="#D44040" stroke-width="2" class="flow-down"/>
+  <line x1="370" y1="212" x2="370" y2="230" stroke="#D44040" stroke-width="2" class="flow-down" style="animation-delay:.15s"/>
+  <line x1="590" y1="212" x2="590" y2="230" stroke="#D44040" stroke-width="2" class="flow-down" style="animation-delay:.3s"/>
+  <line x1="810" y1="212" x2="810" y2="230" stroke="#D44040" stroke-width="2" class="flow-down" style="animation-delay:.45s"/>
+  <!-- horizontal bus -->
+  <line x1="150" y1="230" x2="810" y2="230" stroke="#D44040" stroke-width="2" class="flow-right"/>
+  <!-- single trunk down to SkillClaw -->
+  <line x1="480" y1="230" x2="480" y2="268" stroke="#D44040" stroke-width="2.5" class="flow-down"/>
+  <polygon points="473,265 487,265 480,279" fill="#D44040"/>
+
+  <!-- ===== SKILLCLAW ZONE ===== -->
+  <rect x="140" y="282" width="680" height="170" rx="16" fill="#EBF4FF" stroke="#B8D4F0" stroke-width="1.5"/>
+
+  <g transform="translate(175, 294)"><circle cx="18" cy="18" r="18" fill="#D4E8FA" stroke="#6AAAD8" stroke-width="1.5"/><path d="M18,6 L10,10 L10,18 C10,24 14,28 18,30 C22,28 26,24 26,18 L26,10 Z" fill="none" stroke="#4A90D4" stroke-width="1.8" stroke-linejoin="round"/><path d="M14,18 L17,21 L23,14" fill="none" stroke="#4A90D4" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></g>
+
+  <text x="224" y="316" font-family="Inter,-apple-system,sans-serif" font-size="22" font-weight="800" fill="#1D4E7E">SKILLCLAW</text>
+
+  <text x="400" y="316" font-family="Inter,-apple-system,sans-serif" font-size="15" fill="#4A90D4" font-weight="600">Cross-pollinate &amp; evolve all skills</text>
+
+  <text x="175" y="347" font-family="Inter,-apple-system,sans-serif" font-size="15" fill="#64748B">Merge skills from A + B + C + D, then evolve together</text>
+
+  <!-- 4-step flow -->
+  <rect x="175" y="365" width="110" height="50" rx="10" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1"/>
+  <text x="230" y="395" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="17" font-weight="800" fill="#2B6FAC">Filter</text>
+
+  <line x1="285" y1="390" x2="315" y2="390" stroke="#6AAAD8" stroke-width="2.5" class="flow-right"/>
+  <polygon points="313,384 325,390 313,396" fill="#6AAAD8"/>
+
+  <rect x="325" y="365" width="110" height="50" rx="10" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1"/>
+  <text x="380" y="395" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="17" font-weight="800" fill="#2B6FAC">Improve</text>
+
+  <line x1="435" y1="390" x2="465" y2="390" stroke="#6AAAD8" stroke-width="2.5" class="flow-right" style="animation-delay:.15s"/>
+  <polygon points="463,384 475,390 463,396" fill="#6AAAD8"/>
+
+  <rect x="475" y="365" width="110" height="50" rx="10" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1"/>
+  <text x="530" y="395" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="17" font-weight="800" fill="#2B6FAC">Verify</text>
+
+  <line x1="585" y1="390" x2="615" y2="390" stroke="#6AAAD8" stroke-width="2.5" class="flow-right" style="animation-delay:.3s"/>
+  <polygon points="613,384 625,390 613,396" fill="#6AAAD8"/>
+
+  <rect x="625" y="365" width="110" height="50" rx="10" fill="#C2D9F0" stroke="#4A90D4" stroke-width="1.5"/>
+  <text x="680" y="395" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="17" font-weight="800" fill="#1D4E7E">Solidify</text>
+
+  <text x="480" y="437" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" fill="#64748B">Real session data drives every step</text>
+
+  <!-- Flowing arrow down to library -->
+  <line x1="480" y1="452" x2="480" y2="490" stroke="#94A3B8" stroke-width="2.5" class="flow-down"/>
+  <polygon points="473,487 487,487 480,501" fill="#94A3B8"/>
+
+  <!-- ===== UNIFIED LIBRARY ===== -->
+  <ellipse cx="480" cy="530" rx="210" ry="30" fill="#D4E8FA" opacity=".3" class="core-pulse"/>
+  <rect x="300" y="504" width="360" height="50" rx="14" fill="url(#libGrad)" stroke="#B8D4F0" stroke-width="1.8" filter="url(#softGlow)"/>
+  <path d="M326,518 L326,534 M336,514 L336,534 M346,518 L346,534" stroke="#2B6FAC" stroke-width="2" stroke-linecap="round"/>
+  <line x1="321" y1="536" x2="351" y2="536" stroke="#2B6FAC" stroke-width="2" stroke-linecap="round"/>
+  <path d="M321,516 L336,508 L351,516" fill="none" stroke="#2B6FAC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="510" y="526" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="18" font-weight="800" fill="#2B6FAC">Unified Skill Library</text>
+  <text x="510" y="546" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="13" font-weight="600" fill="#3A7CBD">Best of A + B + C + D &#xB7; Evolved &#xB7; Verified</text>
+
+  <!-- ===== BOTTOM DIVERGING ARROWS: Library -> agents ===== -->
+  <!-- single trunk down from library -->
+  <line x1="480" y1="554" x2="480" y2="572" stroke="#4A90D4" stroke-width="2.5" class="flow-down"/>
+  <!-- horizontal bus -->
+  <line x1="150" y1="572" x2="810" y2="572" stroke="#4A90D4" stroke-width="2" class="flow-right" style="animation-delay:.1s"/>
+  <!-- 4 short lines down to each agent -->
+  <line x1="150" y1="572" x2="150" y2="606" stroke="#4A90D4" stroke-width="2" class="flow-down" style="animation-delay:.15s"/>
+  <polygon points="143,603 157,603 150,617" fill="#4A90D4"/>
+  <line x1="370" y1="572" x2="370" y2="606" stroke="#4A90D4" stroke-width="2" class="flow-down" style="animation-delay:.25s"/>
+  <polygon points="363,603 377,603 370,617" fill="#4A90D4"/>
+  <line x1="590" y1="572" x2="590" y2="606" stroke="#4A90D4" stroke-width="2" class="flow-down" style="animation-delay:.35s"/>
+  <polygon points="583,603 597,603 590,617" fill="#4A90D4"/>
+  <line x1="810" y1="572" x2="810" y2="606" stroke="#4A90D4" stroke-width="2" class="flow-down" style="animation-delay:.45s"/>
+  <polygon points="803,603 817,603 810,617" fill="#4A90D4"/>
+
+  <!-- ===== ENRICHED AGENTS (bottom row) ===== -->
+  <!-- Agent A -->
+  <rect x="50" y="618" width="200" height="80" rx="12" fill="#F5F9FF" stroke="#B8D4F0" stroke-width="1.5"/>
+  <g transform="translate(66, 626)"><circle cx="12" cy="12" r="12" fill="#D4E8FA" stroke="#6AAAD8" stroke-width="1.2"/><path d="M13,4 L9,12 L12,12 L11,20 L15,10 L12,10 Z" fill="#6AAAD8"/></g>
+  <text x="96" y="644" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="800" fill="#2B6FAC">Hermes A</text>
+  <text x="184" y="644" font-family="Inter,-apple-system,sans-serif" font-size="13" font-weight="700" fill="#4A90D4">4x &#x2191;</text>
+  <rect x="66" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#C2D9F0" stroke-width=".8"/>
+  <text x="87" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#4A90D4">Front</text>
+  <rect x="112" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="133" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Back</text>
+  <rect x="158" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="179" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Ops</text>
+  <rect x="204" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="225" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Data</text>
+  <text x="66" y="688" font-family="Inter,-apple-system,sans-serif" font-size="11" fill="#3A7CBD">+ Backend, DevOps, Data skills</text>
+
+  <!-- Agent B -->
+  <rect x="270" y="618" width="200" height="80" rx="12" fill="#F5F9FF" stroke="#B8D4F0" stroke-width="1.5"/>
+  <g transform="translate(286, 626)"><circle cx="12" cy="12" r="12" fill="#D4E8FA" stroke="#6AAAD8" stroke-width="1.2"/><path d="M13,4 L9,12 L12,12 L11,20 L15,10 L12,10 Z" fill="#6AAAD8"/></g>
+  <text x="316" y="644" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="800" fill="#2B6FAC">Hermes B</text>
+  <text x="404" y="644" font-family="Inter,-apple-system,sans-serif" font-size="13" font-weight="700" fill="#4A90D4">4x &#x2191;</text>
+  <rect x="286" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="307" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Front</text>
+  <rect x="332" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#C2D9F0" stroke-width=".8"/>
+  <text x="353" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#4A90D4">Back</text>
+  <rect x="378" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="399" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Ops</text>
+  <rect x="424" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="445" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Data</text>
+  <text x="286" y="688" font-family="Inter,-apple-system,sans-serif" font-size="11" fill="#3A7CBD">+ Frontend, DevOps, Data skills</text>
+
+  <!-- Agent C -->
+  <rect x="490" y="618" width="200" height="80" rx="12" fill="#F5F9FF" stroke="#B8D4F0" stroke-width="1.5"/>
+  <g transform="translate(506, 626)"><circle cx="12" cy="12" r="12" fill="#D4E8FA" stroke="#6AAAD8" stroke-width="1.2"/><path d="M13,4 L9,12 L12,12 L11,20 L15,10 L12,10 Z" fill="#6AAAD8"/></g>
+  <text x="536" y="644" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="800" fill="#2B6FAC">Hermes C</text>
+  <text x="624" y="644" font-family="Inter,-apple-system,sans-serif" font-size="13" font-weight="700" fill="#4A90D4">4x &#x2191;</text>
+  <rect x="506" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="527" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Front</text>
+  <rect x="552" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="573" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Back</text>
+  <rect x="598" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#C2D9F0" stroke-width=".8"/>
+  <text x="619" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#4A90D4">Ops</text>
+  <rect x="644" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="665" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Data</text>
+  <text x="506" y="688" font-family="Inter,-apple-system,sans-serif" font-size="11" fill="#3A7CBD">+ Frontend, Backend, Data skills</text>
+
+  <!-- Agent D -->
+  <rect x="710" y="618" width="200" height="80" rx="12" fill="#F5F9FF" stroke="#B8D4F0" stroke-width="1.5"/>
+  <g transform="translate(726, 626)"><circle cx="12" cy="12" r="12" fill="#D4E8FA" stroke="#6AAAD8" stroke-width="1.2"/><path d="M13,4 L9,12 L12,12 L11,20 L15,10 L12,10 Z" fill="#6AAAD8"/></g>
+  <text x="756" y="644" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="800" fill="#2B6FAC">Hermes D</text>
+  <text x="844" y="644" font-family="Inter,-apple-system,sans-serif" font-size="13" font-weight="700" fill="#4A90D4">4x &#x2191;</text>
+  <rect x="726" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="747" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Front</text>
+  <rect x="772" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="793" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Back</text>
+  <rect x="818" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#B8D4F0" stroke-width=".8"/>
+  <text x="839" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#2B6FAC">Ops</text>
+  <rect x="864" y="654" width="42" height="16" rx="4" fill="#D4E8FA" stroke="#C2D9F0" stroke-width=".8"/>
+  <text x="885" y="666" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="9" font-weight="700" fill="#4A90D4">Data</text>
+  <text x="726" y="688" font-family="Inter,-apple-system,sans-serif" font-size="11" fill="#3A7CBD">+ Frontend, Backend, Ops skills</text>
+
+  <!-- KEY INSIGHT -->
+  <rect x="160" y="714" width="640" height="50" rx="14" fill="#F5F9FF" stroke="#C2D9F0" stroke-width="1.5"/>
+  <text x="480" y="736" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="17" font-weight="800" fill="#2B6FAC">Every agent learns from every other agent's experience</text>
+  <text x="480" y="754" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" fill="#3A7CBD">N agents &#xD7; M tasks = N&#xD7;M skill sources &#x2192; exponential collective growth</text>
+
+</svg>

--- a/assets/two_loops.svg
+++ b/assets/two_loops.svg
@@ -1,0 +1,233 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 870" width="960" height="870">
+  <defs>
+    <linearGradient id="titleGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#D44040"/>
+      <stop offset="100%" stop-color="#4A90D4"/>
+    </linearGradient>
+    <linearGradient id="feedbackGrad" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#6AAAD8"/>
+      <stop offset="100%" stop-color="#B8D4F0"/>
+    </linearGradient>
+    <linearGradient id="libGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#D4E8FA"/>
+      <stop offset="100%" stop-color="#C2D9F0"/>
+    </linearGradient>
+    <linearGradient id="dividerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="20%" stop-color="#F0CDCB"/>
+      <stop offset="50%" stop-color="#E2E8F0"/>
+      <stop offset="80%" stop-color="#B8D4F0"/>
+      <stop offset="100%" stop-color="#FFFFFF"/>
+    </linearGradient>
+    <linearGradient id="evolveArrow" x1="355" y1="0" x2="435" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#E8A0A0"/>
+      <stop offset="100%" stop-color="#4A90D4"/>
+    </linearGradient>
+    <marker id="arrowGray" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,1.5 L8,5 L0,8.5" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arrowBlue" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,1.5 L8,5 L0,8.5" fill="none" stroke="#6AAAD8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 12 12" refX="11" refY="6" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0,1 L11,6 L0,11 z" fill="#6AAAD8"/>
+    </marker>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="evolvedGlow">
+      <feGaussianBlur stdDeviation="3" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <style>
+    @keyframes flowDash{to{stroke-dashoffset:-24}}
+    @keyframes pulse{0%,100%{opacity:1}50%{opacity:.55}}
+    @keyframes corePulse{0%,100%{opacity:.85}50%{opacity:1}}
+    @keyframes growBar{0%,100%{opacity:.7}50%{opacity:1}}
+    .flow-line{animation:flowDash 1.8s linear infinite}
+    .pulse{animation:pulse 2.5s ease-in-out infinite}
+    .core-pulse{animation:corePulse 3s ease-in-out infinite}
+    .grow-bar{animation:growBar 2s ease-in-out infinite}
+  </style>
+
+  <!-- Background -->
+  <rect width="960" height="870" rx="18" fill="#FFFFFF"/>
+  <rect width="960" height="870" rx="18" fill="none" stroke="#E2E8F0" stroke-width="1"/>
+
+  <!-- ===== TITLE ===== -->
+  <text x="480" y="44" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="18" font-weight="800" letter-spacing="6" fill="url(#titleGrad)">TWO LOOPS, ONE EVOLUTION</text>
+  <text x="480" y="80" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="30" font-weight="900" fill="#0F172A">Hermes &#xD7; SkillClaw</text>
+  <rect x="50" y="96" width="860" height="2" rx="1" fill="url(#dividerGrad)"/>
+
+  <!-- ===== TASK BOX ===== -->
+  <rect x="340" y="116" width="260" height="60" rx="14" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.2"/>
+  <rect x="370" y="130" width="22" height="28" rx="3" fill="none" stroke="#94A3B8" stroke-width="1.5"/>
+  <rect x="375" y="126" width="12" height="6" rx="2" fill="#94A3B8"/>
+  <line x1="376" y1="139" x2="386" y2="139" stroke="#CBD5E1" stroke-width="1.2"/>
+  <line x1="376" y1="145" x2="386" y2="145" stroke="#CBD5E1" stroke-width="1.2"/>
+  <line x1="376" y1="151" x2="383" y2="151" stroke="#CBD5E1" stroke-width="1.2"/>
+  <text x="470" y="153" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="24" font-weight="700" fill="#334155">Task N</text>
+
+  <!-- Arrow: Task to Hermes -->
+  <line x1="470" y1="176" x2="470" y2="210" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrowGray)"/>
+
+  <!-- ===== LOOP 1: HERMES ZONE ===== -->
+  <rect x="100" y="220" width="620" height="165" rx="16" fill="#FEF7F7" stroke="#F0CDCB" stroke-width="1.5"/>
+
+  <!-- Hermes Icon -->
+  <g transform="translate(135, 238)">
+    <circle cx="18" cy="18" r="18" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1.5"/>
+    <path d="M20,6 L12,20 L18,20 L16,30 L24,16 L18,16 Z" fill="#D44040"/>
+  </g>
+
+  <rect x="180" y="240" width="42" height="24" rx="6" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1"/>
+  <text x="201" y="257" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="13" font-weight="800" fill="#D44040">L1</text>
+  <text x="234" y="258" font-family="Inter,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#B5302A">HERMES</text>
+  <text x="420" y="258" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="600" fill="#C0392B">During Task</text>
+
+  <!-- Skill cards -->
+  <g transform="translate(145, 280)">
+    <!-- new skill card -->
+    <rect x="0" y="0" width="155" height="62" rx="10" fill="#FFFFFF" stroke="#E8A0A0" stroke-width="1.2" class="pulse"/>
+    <rect x="12" y="10" width="78" height="16" rx="4" fill="#FCEAEA"/>
+    <text x="51" y="22" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#D44040">new skill</text>
+    <rect x="12" y="32" width="115" height="6" rx="3" fill="#F0CDCB"/>
+    <rect x="12" y="44" width="85" height="6" rx="3" fill="#F0CDCB" opacity=".6"/>
+    <!-- Plus icon (create new) -->
+    <line x1="130" y1="11" x2="130" y2="25" stroke="#D44040" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="123" y1="18" x2="137" y2="18" stroke="#D44040" stroke-width="2.5" stroke-linecap="round"/>
+
+    <!-- edit skill card -->
+    <rect x="175" y="0" width="155" height="62" rx="10" fill="#FFFFFF" stroke="#D44040" stroke-width="1.2" stroke-dasharray="4 2" class="pulse" style="animation-delay:.4s"/>
+    <rect x="187" y="10" width="78" height="16" rx="4" fill="#FCEAEA"/>
+    <text x="226" y="22" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#D44040">edit skill</text>
+    <rect x="187" y="32" width="120" height="6" rx="3" fill="#F0CDCB"/>
+    <rect x="187" y="44" width="78" height="6" rx="3" fill="#F0CDCB" opacity=".6"/>
+    <!-- Gear icon -->
+    <circle cx="310" cy="14" r="7" fill="none" stroke="#D44040" stroke-width="1.8"/>
+    <circle cx="310" cy="14" r="2.5" fill="#D44040"/>
+  </g>
+
+  <text x="520" y="306" font-family="Inter,-apple-system,sans-serif" font-size="18" font-weight="700" fill="#78350F">Hermes already writes</text>
+  <text x="520" y="330" font-family="Inter,-apple-system,sans-serif" font-size="18" font-weight="700" fill="#78350F">and edits skills in-task</text>
+  <text x="520" y="358" font-family="Inter,-apple-system,sans-serif" font-size="16" fill="#C0392B">Ad-hoc &#xB7; In the moment</text>
+
+  <!-- Arrow: Hermes to SkillClaw -->
+  <line x1="470" y1="385" x2="470" y2="428" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrowGray)"/>
+  <rect x="410" y="398" width="120" height="22" rx="6" fill="#F1F5F9"/>
+  <text x="470" y="414" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#94A3B8">Task Done &#x2713;</text>
+
+  <!-- ===== LOOP 2: SKILLCLAW ZONE ===== -->
+  <rect x="100" y="438" width="620" height="310" rx="16" fill="#EBF4FF" stroke="#B8D4F0" stroke-width="1.5"/>
+
+  <!-- SkillClaw Icon -->
+  <g transform="translate(135, 456)">
+    <circle cx="18" cy="18" r="18" fill="#D4E8FA" stroke="#6AAAD8" stroke-width="1.5"/>
+    <path d="M18,6 L10,10 L10,18 C10,24 14,28 18,30 C22,28 26,24 26,18 L26,10 Z" fill="none" stroke="#4A90D4" stroke-width="1.8" stroke-linejoin="round"/>
+    <path d="M14,18 L17,21 L23,14" fill="none" stroke="#4A90D4" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <rect x="180" y="458" width="42" height="24" rx="6" fill="#D4E8FA" stroke="#6AAAD8" stroke-width="1"/>
+  <text x="201" y="475" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="13" font-weight="800" fill="#2B6FAC">L2</text>
+  <text x="234" y="476" font-family="Inter,-apple-system,sans-serif" font-size="24" font-weight="800" fill="#1D4E7E">SKILLCLAW</text>
+  <text x="425" y="476" font-family="Inter,-apple-system,sans-serif" font-size="16" font-weight="600" fill="#4A90D4">After Task</text>
+
+  <text x="145" y="510" font-family="Inter,-apple-system,sans-serif" font-size="17" font-weight="600" fill="#2B6FAC">Driven by real session data</text>
+
+  <!-- 4-Step Process -->
+  <rect x="130" y="528" width="125" height="68" rx="12" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1.2"/>
+  <path d="M180,539 L205,539 L198,550 L198,558 L187,558 L187,550 Z" fill="none" stroke="#4A90D4" stroke-width="1.5" stroke-linejoin="round"/>
+  <text x="192" y="579" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="20" font-weight="800" fill="#2B6FAC">Filter</text>
+
+  <line x1="255" y1="562" x2="280" y2="562" stroke="#6AAAD8" stroke-width="2.5" marker-end="url(#arrowBlue)"/>
+
+  <rect x="286" y="528" width="125" height="68" rx="12" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1.2"/>
+  <path d="M343,558 L343,542 M337,548 L343,542 L349,548" fill="none" stroke="#4A90D4" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="348" y="579" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="20" font-weight="800" fill="#2B6FAC">Improve</text>
+
+  <line x1="411" y1="562" x2="436" y2="562" stroke="#6AAAD8" stroke-width="2.5" marker-end="url(#arrowBlue)"/>
+
+  <rect x="442" y="528" width="125" height="68" rx="12" fill="#D4E8FA" stroke="#B8D4F0" stroke-width="1.2"/>
+  <path d="M494,544 L501,552 L511,539" fill="none" stroke="#4A90D4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="504" y="579" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="20" font-weight="800" fill="#2B6FAC">Verify</text>
+
+  <line x1="567" y1="562" x2="592" y2="562" stroke="#6AAAD8" stroke-width="2.5" marker-end="url(#arrowBlue)"/>
+
+  <rect x="598" y="528" width="112" height="68" rx="12" fill="#C2D9F0" stroke="#4A90D4" stroke-width="2"/>
+  <path d="M654,539 L664,549 L654,559 L644,549 Z" fill="none" stroke="#1D4E7E" stroke-width="1.8" stroke-linejoin="round"/>
+  <text x="654" y="579" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="20" font-weight="800" fill="#1D4E7E">Solidify</text>
+
+  <!-- Down arrow: steps to result -->
+  <line x1="410" y1="596" x2="410" y2="630" stroke="#6AAAD8" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <text x="438" y="622" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#4A90D4">RESULT</text>
+
+  <!-- ===== SKILL EVOLUTION RESULT ===== -->
+  <!-- Before: raw skill -->
+  <rect x="135" y="640" width="195" height="88" rx="10" fill="#FEF7F7" stroke="#E8A0A0" stroke-width="1.2" stroke-dasharray="5 3" opacity=".9"/>
+  <rect x="150" y="650" width="52" height="16" rx="4" fill="#FCEAEA"/>
+  <text x="176" y="662" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#D44040">v1.0</text>
+  <text x="215" y="662" font-family="Inter,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#B5302A">Raw Skill</text>
+  <rect x="150" y="674" width="100" height="6" rx="3" fill="#F0CDCB"/>
+  <rect x="150" y="686" width="70" height="6" rx="3" fill="#F0CDCB" opacity=".7"/>
+  <rect x="150" y="698" width="45" height="6" rx="3" fill="#F0CDCB" opacity=".4"/>
+  <text x="150" y="718" font-family="Inter,-apple-system,sans-serif" font-size="14" fill="#C0392B">2 capabilities</text>
+
+  <!-- Evolution arrow -->
+  <rect x="345" y="680" width="80" height="4" rx="2" fill="url(#evolveArrow)"/>
+  <polygon points="425,674 437,682 425,690" fill="#4A90D4"/>
+  <text x="390" y="672" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="15" font-weight="800" fill="#6366F1">EVOLVED</text>
+
+  <!-- After: evolved skill -->
+  <rect x="452" y="640" width="240" height="88" rx="10" fill="#EBF4FF" stroke="#4A90D4" stroke-width="2" filter="url(#evolvedGlow)"/>
+  <rect x="466" y="650" width="52" height="16" rx="4" fill="#D4E8FA"/>
+  <text x="492" y="662" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#2B6FAC">v2.0</text>
+  <text x="534" y="662" font-family="Inter,-apple-system,sans-serif" font-size="15" font-weight="800" fill="#1D4E7E">Evolved Skill</text>
+  <!-- Star (placed after text with spacing) -->
+  <path d="M660,648 L663,655 L670,656 L665,660 L666,668 L660,664 L654,668 L655,660 L650,656 L657,655 Z" fill="#4A90D4" opacity=".6"/>
+  <rect x="466" y="674" width="170" height="6" rx="3" fill="#B8D4F0" class="grow-bar"/>
+  <rect x="466" y="686" width="148" height="6" rx="3" fill="#B8D4F0" class="grow-bar" style="animation-delay:.2s"/>
+  <rect x="466" y="698" width="125" height="6" rx="3" fill="#B8D4F0" class="grow-bar" style="animation-delay:.4s"/>
+  <rect x="466" y="710" width="100" height="6" rx="3" fill="#6AAAD8" class="grow-bar" style="animation-delay:.6s"/>
+  <text x="466" y="724" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#2B6FAC">5 capabilities &#x2191;</text>
+
+  <!-- Bottom annotation -->
+  <text x="420" y="742" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="16" fill="#475569">Keep what works &#xB7; Discard what doesn't &#xB7; Evolve continuously</text>
+
+  <!-- Arrow: SkillClaw to Library -->
+  <line x1="470" y1="748" x2="470" y2="778" stroke="#94A3B8" stroke-width="2.5" marker-end="url(#arrowGray)"/>
+
+  <!-- ===== SKILL LIBRARY ===== -->
+  <ellipse cx="430" cy="812" rx="180" ry="30" fill="#D4E8FA" opacity=".3" class="core-pulse"/>
+  <rect x="280" y="788" width="300" height="56" rx="14" fill="url(#libGrad)" stroke="#B8D4F0" stroke-width="1.8" filter="url(#softGlow)"/>
+  <path d="M310,808 L310,820 M320,804 L320,820 M330,808 L330,820" stroke="#2B6FAC" stroke-width="2" stroke-linecap="round"/>
+  <line x1="305" y1="822" x2="335" y2="822" stroke="#2B6FAC" stroke-width="2" stroke-linecap="round"/>
+  <path d="M305,806 L320,798 L335,806" fill="none" stroke="#2B6FAC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="450" y="814" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="20" font-weight="800" fill="#2B6FAC">Stronger Skills</text>
+  <text x="450" y="834" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#3A7CBD">Personal &#xB7; Evolved &#xB7; Persistent</text>
+
+  <!-- ===== FEEDBACK LOOP ARROW ===== -->
+  <path d="M580,816 C760,816 820,660 820,540 C820,350 770,302 720,302"
+        fill="none" stroke="url(#feedbackGrad)" stroke-width="3.5"
+        stroke-dasharray="9 5" class="flow-line" marker-end="url(#arrowGreen)"/>
+
+  <!-- Stronger Next Time (vertical along arrow) -->
+  <text transform="rotate(90,845,500)" x="845" y="500" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="17" font-weight="800" letter-spacing="2" fill="#4A90D4">STRONGER NEXT TIME</text>
+
+  <!-- ===== SIDE ANNOTATIONS ===== -->
+  <rect x="12" y="278" width="78" height="74" rx="10" fill="#FCEAEA" stroke="#E8A0A0" stroke-width="1" opacity=".85"/>
+  <text x="51" y="305" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#B5302A">One-off</text>
+  <text x="51" y="324" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#B5302A">Ad-hoc</text>
+  <text x="51" y="343" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" fill="#C0392B">&#x2193;</text>
+
+  <line x1="51" y1="352" x2="51" y2="540" stroke="#CBD5E1" stroke-width="1.2" stroke-dasharray="3 3"/>
+
+  <rect x="12" y="545" width="78" height="74" rx="10" fill="#D4E8FA" stroke="#6AAAD8" stroke-width="1" opacity=".85"/>
+  <text x="51" y="573" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#1D4E7E">Evolving</text>
+  <text x="51" y="592" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#1D4E7E">Asset</text>
+  <text x="51" y="611" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="12" fill="#2B6FAC">&#x2191; upgrade</text>
+
+  <!-- ===== BOTTOM TAGLINE ===== -->
+  <text x="430" y="860" text-anchor="middle" font-family="Inter,-apple-system,sans-serif" font-size="16" fill="#64748B">Hermes writes skills during tasks &#xB7; SkillClaw decides which survive, improve, and return stronger</text>
+</svg>

--- a/evolve_server/engines/workflow.py
+++ b/evolve_server/engines/workflow.py
@@ -147,6 +147,26 @@ class EvolveServer:
     def _load_remote_skills(self) -> dict[str, dict[str, Any]]:
         return load_manifest(self._bucket, self._prefix)
 
+    def _load_remote_skill_record(self, name: str) -> Optional[dict[str, Any]]:
+        rec = self._load_remote_skills().get(name)
+        return rec if isinstance(rec, dict) else None
+
+    @staticmethod
+    def _overlay_manifest_metadata(
+        skill: Optional[dict[str, Any]],
+        manifest_record: Optional[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        if not skill or not manifest_record:
+            return skill
+        category = str(manifest_record.get("category", "") or "").strip()
+        if category and str(skill.get("category", "general") or "general").strip() == "general":
+            skill["category"] = category
+        if not str(skill.get("description", "") or "").strip():
+            description = str(manifest_record.get("description", "") or "").strip()
+            if description:
+                skill["description"] = description
+        return skill
+
     def _fetch_skill(self, name: str) -> Optional[str]:
         return fetch_skill_content(self._bucket, self._prefix, name)
 
@@ -205,6 +225,10 @@ class EvolveServer:
             return action_type
 
         existing_skill = parse_skill_content(name, existing_md)
+        existing_skill = self._overlay_manifest_metadata(
+            existing_skill,
+            self._load_remote_skill_record(name),
+        )
         existing_skill["_version"] = self._id_registry.get_version(name)
         merged = await execute_merge(self._llm, existing_skill, skill)
         if merged and merged.get("name"):
@@ -653,6 +677,10 @@ class EvolveServer:
     ) -> Optional[dict]:
         current_md = await self._call_storage(self._fetch_skill, skill_name)
         current_skill = parse_skill_content(skill_name, current_md) if current_md else None
+        current_skill = self._overlay_manifest_metadata(
+            current_skill,
+            await self._call_storage(self._load_remote_skill_record, skill_name),
+        )
 
         result = await evolve_skill_from_sessions(
             self._llm,
@@ -716,6 +744,7 @@ class EvolveServer:
         skill_group_count = 0
         no_skill_sessions: list[dict] = []
         evolution_records: list[dict] = []
+        had_processing_error = False
 
         if sessions:
             logger.info("[EvolveServer] summarizing %d sessions", len(sessions))
@@ -736,15 +765,20 @@ class EvolveServer:
                     record = await self._evolve_skill_group(skill_name, skill_sessions, existing_skill_names)
                 except Exception as exc:
                     logger.error("[EvolveServer] skill '%s' evolve failed: %s", skill_name, exc)
+                    had_processing_error = True
                     continue
                 if record:
                     evolution_records.append(record)
 
             if no_skill_sessions:
                 logger.info("[EvolveServer] processing %d no-skill sessions", len(no_skill_sessions))
-                evolution_records.extend(
-                    await self._handle_no_skill_sessions(no_skill_sessions, existing_skill_names)
-                )
+                try:
+                    evolution_records.extend(
+                        await self._handle_no_skill_sessions(no_skill_sessions, existing_skill_names)
+                    )
+                except Exception as exc:
+                    logger.error("[EvolveServer] no-skill evolve failed: %s", exc)
+                    had_processing_error = True
         else:
             logger.info("[EvolveServer] queue empty - checking pending validation publish jobs")
 
@@ -752,8 +786,13 @@ class EvolveServer:
         all_records = evolution_records + published_records
 
         await self._call_storage(self._id_registry.save_to_oss, self._bucket, self._prefix)
-        if session_keys:
+        if session_keys and not had_processing_error:
             await self._call_storage(delete_session_keys, self._bucket, session_keys)
+        elif session_keys and had_processing_error:
+            logger.warning(
+                "[EvolveServer] retaining %d session(s) in queue because this cycle had processing errors",
+                len(session_keys),
+            )
 
         elapsed = round(time.monotonic() - started_at, 1)
         uploaded_skills = sum(1 for record in all_records if record.get("uploaded"))
@@ -779,6 +818,7 @@ class EvolveServer:
             "session_judge": judge_summary,
             "skill_verifier": skill_verifier_summary,
             "validation_publish": validation_publish_summary,
+            "had_processing_error": had_processing_error,
         }
         self._append_history(summary)
         logger.info(

--- a/evolve_server/pipeline/summarizer.py
+++ b/evolve_server/pipeline/summarizer.py
@@ -191,6 +191,11 @@ def _format_step(
         name = s.get("skill_name", "").strip() if isinstance(s, dict) else str(s or "").strip()
         if name:
             skills.append(name)
+    modified = []
+    for s in turn.get("modified_skills") or []:
+        name = s.get("skill_name", "").strip() if isinstance(s, dict) else str(s or "").strip()
+        if name:
+            modified.append(name)
     injected = [str(s or "").strip() for s in (turn.get("injected_skills") or []) if str(s or "").strip()]
 
     prm = turn.get("prm_score")
@@ -201,6 +206,8 @@ def _format_step(
         header_parts.append(prm_str)
     if skills:
         header_parts.append(f"read_skills={skills}")
+    if modified:
+        header_parts.append(f"modified_skills={modified}")
     if injected:
         header_parts.append(f"injected={injected}")
     header = " | ".join(header_parts)
@@ -234,8 +241,9 @@ Given a complete agent session, produce a trajectory-aware analytical summary \
 2. **Key trajectory**: The step-by-step path the agent took — what it tried, \
 in what order, and why (e.g., "read skill X → attempted approach Y → hit \
 error Z → switched to W").
-3. **Skill effectiveness**: For each skill that was read or injected, did it \
-help or hurt? Was it relevant to the task? Was any guidance missing or wrong?
+3. **Skill effectiveness**: For each skill that was read, injected, or \
+modified, did it help or hurt? Was it relevant to the task? Was any guidance \
+missing or wrong?
 4. **Critical turning points**: Where things went right or wrong. What \
 caused failures? What enabled successes?
 5. **Tool usage patterns**: Which tools were used effectively, which caused \
@@ -292,6 +300,12 @@ def _build_session_payload(session: dict) -> dict[str, Any]:
                 s.get("skill_name", "") if isinstance(s, dict) else str(s or "")
                 for s in read_skills
             ]
+        modified_skills = t.get("modified_skills") or []
+        if modified_skills:
+            interaction["modified_skills"] = [
+                s.get("skill_name", "") if isinstance(s, dict) else str(s or "")
+                for s in modified_skills
+            ]
         injected = t.get("injected_skills") or []
         if injected:
             interaction["injected_skills"] = injected
@@ -335,7 +349,9 @@ def _extract_session_metadata(session: dict) -> None:
     """Extract skill references and compute aggregate metrics for a session.
 
     Attaches the following keys directly to the session dict:
-    - ``_skills_referenced``: set of skill names referenced by any interaction
+    - ``_skills_referenced``: set of skill names explicitly read or modified
+      by any interaction. Prompt-time injection alone is not treated as
+      evidence that the session actually used that skill.
     - ``_prm_scores``: list of all non-None PRM scores
     - ``_avg_prm``: mean PRM (or None if no scores)
     - ``_has_tool_errors``: True if any interaction had tool errors
@@ -353,8 +369,12 @@ def _extract_session_metadata(session: dict) -> None:
             )
             if name:
                 skills.add(name)
-        for item in turn.get("injected_skills") or []:
-            name = str(item or "").strip()
+        for item in turn.get("modified_skills") or []:
+            name = (
+                item.get("skill_name", "").strip()
+                if isinstance(item, dict)
+                else str(item or "").strip()
+            )
             if name:
                 skills.add(name)
         prm = turn.get("prm_score")

--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -109,6 +109,51 @@ _SESSION_SWEEP_INTERVAL_SECONDS = 15
 _SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 15
 _VALID_TURN_TYPES = {"main", "side"}
 _TRUE_STRINGS = {"1", "true", "yes", "on"}
+_READ_TOOL_NAMES = {"read", "file_read", "read_file", "readfile"}
+_HERMES_SKILL_READ_TOOL_NAMES = {"skill_view"}
+_SKILL_WRITE_TOOL_NAMES = {
+    "write",
+    "file_write",
+    "write_file",
+    "writefile",
+    "create_file",
+    "edit",
+    "edit_file",
+    "replace",
+    "replace_in_file",
+    "append",
+    "append_file",
+    "patch",
+    "apply_patch",
+    "move",
+    "rename",
+    "mv",
+}
+_HERMES_SKILL_WRITE_TOOL_NAMES = {"skill_manage"}
+_SHELL_TOOL_NAMES = {"shell", "exec", "bash", "terminal"}
+_PATCH_PATH_RE = re.compile(r"^\*\*\* (?:Add|Update|Delete) File: (.+)$", re.MULTILINE)
+_SHELL_SKILL_PATH_RE = re.compile(r"([~./A-Za-z0-9_\-][^\n\"'`]*?SKILL\.md)")
+
+
+def _extract_skill_names(items: list[Any] | None) -> set[str]:
+    names: set[str] = set()
+    for item in items or []:
+        if isinstance(item, dict):
+            raw = item.get("skill_name") or item.get("name") or item.get("skill")
+        else:
+            raw = item
+        name = str(raw or "").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _extract_modified_skill_names(turns: list[dict] | None) -> set[str]:
+    names: set[str] = set()
+    for turn in turns or []:
+        if isinstance(turn, dict):
+            names.update(_extract_skill_names(turn.get("modified_skills")))
+    return names
 
 
 def _llm_request_timeout_seconds() -> float:
@@ -177,6 +222,167 @@ def _normalize_tool_name(raw_name: str, args_raw: str) -> str:
         if isinstance(args_obj.get("sessionId"), str) and args_obj.get("sessionId"):
             return "process"
     return "unknown_tool"
+
+
+def _normalize_tool_call_name(raw_name: str) -> str:
+    """Strip transport-specific prefixes from a tool name."""
+    name = str(raw_name or "").strip()
+    if name.startswith("functions."):
+        return name.split(".", 1)[1]
+    return name
+
+
+def _deduplicate_paths(paths: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for path in paths:
+        clean = str(path or "").strip()
+        if not clean or clean in seen:
+            continue
+        seen.add(clean)
+        out.append(clean)
+    return out
+
+
+def _extract_skill_paths_from_patch(raw_text: str) -> list[str]:
+    return _deduplicate_paths([
+        match.group(1).strip()
+        for match in _PATCH_PATH_RE.finditer(str(raw_text or ""))
+        if match.group(1).strip().endswith("SKILL.md")
+    ])
+
+
+def _extract_skill_paths_from_shell(command: str) -> list[str]:
+    return _deduplicate_paths([
+        match.group(1).strip()
+        for match in _SHELL_SKILL_PATH_RE.finditer(str(command or ""))
+        if match.group(1).strip().endswith("SKILL.md")
+    ])
+
+
+def _extract_skill_paths_from_args_dict(args: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    for key in (
+        "path",
+        "file",
+        "file_path",
+        "target",
+        "destination",
+        "dest",
+        "to",
+        "source",
+        "src",
+        "old_path",
+        "new_path",
+    ):
+        value = args.get(key)
+        if isinstance(value, str) and value.strip().endswith("SKILL.md"):
+            paths.append(value.strip())
+
+    raw_paths = args.get("paths")
+    if isinstance(raw_paths, list):
+        for item in raw_paths:
+            if isinstance(item, str) and item.strip().endswith("SKILL.md"):
+                paths.append(item.strip())
+    return _deduplicate_paths(paths)
+
+
+def _extract_skill_paths_from_tool_call(tool_call: dict) -> tuple[str, list[str]]:
+    func = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+    tool_name = _normalize_tool_call_name(func.get("name") or "")
+    args_raw = func.get("arguments", "{}")
+    if not isinstance(args_raw, str):
+        try:
+            args_raw = json.dumps(args_raw, ensure_ascii=False)
+        except Exception:
+            args_raw = "{}"
+
+    paths: list[str] = []
+    args_obj: Any = None
+    try:
+        args_obj = json.loads(args_raw)
+    except Exception:
+        args_obj = None
+
+    if isinstance(args_obj, dict):
+        paths.extend(_extract_skill_paths_from_args_dict(args_obj))
+        if tool_name.lower() in _SHELL_TOOL_NAMES:
+            command = str(args_obj.get("command") or args_obj.get("cmd") or "")
+            paths.extend(_extract_skill_paths_from_shell(command))
+
+    if tool_name.lower() in {"apply_patch", "patch"}:
+        paths.extend(_extract_skill_paths_from_patch(args_raw))
+    elif tool_name.lower() in _SHELL_TOOL_NAMES:
+        paths.extend(_extract_skill_paths_from_shell(args_raw))
+
+    return tool_name, _deduplicate_paths(paths)
+
+
+def _extract_hermes_skill_name_from_tool_call(tool_call: dict) -> tuple[str, str]:
+    """Extract Hermes-native skill names from skill_view / skill_manage calls."""
+    func = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+    tool_name = _normalize_tool_call_name(func.get("name") or "")
+    args_raw = func.get("arguments", "{}")
+    if not isinstance(args_raw, str):
+        try:
+            args_raw = json.dumps(args_raw, ensure_ascii=False)
+        except Exception:
+            args_raw = "{}"
+
+    try:
+        args_obj = json.loads(args_raw)
+    except Exception:
+        args_obj = {}
+
+    if not isinstance(args_obj, dict):
+        return tool_name, ""
+
+    for key in ("skill_name", "name", "skill"):
+        value = args_obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return tool_name, value.strip()
+    return tool_name, ""
+
+
+def _resolve_skill_reference(
+    path: str,
+    skill_path_map: dict[str, dict[str, str]],
+) -> dict[str, str]:
+    expanded = os.path.expanduser(str(path or "").strip())
+    real_path = os.path.realpath(expanded) if expanded else ""
+    skill_info = (
+        skill_path_map.get(real_path)
+        or skill_path_map.get(expanded)
+        or skill_path_map.get(str(path or "").strip())
+    )
+    if skill_info:
+        return {
+            "skill_id": str(skill_info.get("skill_id", "") or ""),
+            "skill_name": str(skill_info.get("skill_name", "") or ""),
+            "path": str(path or "").strip(),
+        }
+    return {
+        "skill_id": "",
+        "skill_name": os.path.basename(os.path.dirname(expanded or str(path or "").strip())),
+        "path": str(path or "").strip(),
+    }
+
+
+def _resolve_skill_reference_by_name(
+    skill_name: str,
+    skill_path_map: dict[str, dict[str, str]],
+) -> dict[str, str]:
+    clean_name = str(skill_name or "").strip()
+    if not clean_name:
+        return {"skill_id": "", "skill_name": "", "path": ""}
+    for path, skill_info in skill_path_map.items():
+        if str(skill_info.get("skill_name", "") or "").strip() == clean_name:
+            return {
+                "skill_id": str(skill_info.get("skill_id", "") or ""),
+                "skill_name": clean_name,
+                "path": str(path or ""),
+            }
+    return {"skill_id": "", "skill_name": clean_name, "path": ""}
 
 def _extract_tool_calls_from_text(text: str) -> tuple[str, list[dict]]:
     """
@@ -589,7 +795,7 @@ def _build_tool_summaries(tool_calls: list[dict]) -> list[dict]:
     summaries: list[dict] = []
     for tc in tool_calls:
         func = tc.get("function", {})
-        name = str(func.get("name", "unknown"))
+        name = _normalize_tool_call_name(func.get("name", "unknown"))
         args_raw = func.get("arguments", "{}")
         if not isinstance(args_raw, str):
             try:
@@ -600,6 +806,7 @@ def _build_tool_summaries(tool_calls: list[dict]) -> list[dict]:
             args = json.loads(args_raw)
         except Exception:
             args = {}
+        _, skill_paths = _extract_skill_paths_from_tool_call(tc)
 
         summary: dict[str, Any] = {
             "tool_name": name,
@@ -608,7 +815,7 @@ def _build_tool_summaries(tool_calls: list[dict]) -> list[dict]:
             "has_error": False,
         }
 
-        if name.lower() in ("shell", "exec", "bash", "terminal"):
+        if name.lower() in _SHELL_TOOL_NAMES:
             cmd = str(args.get("command") or args.get("cmd") or "")
             if cmd:
                 summary["command"] = cmd[:_TOOL_ARGS_MAX_CHARS]
@@ -616,6 +823,8 @@ def _build_tool_summaries(tool_calls: list[dict]) -> list[dict]:
         path = str(args.get("path") or args.get("file") or args.get("file_path") or "")
         if path:
             summary["path"] = path
+        elif skill_paths:
+            summary["path"] = skill_paths[0]
 
         summaries.append(summary)
     return summaries
@@ -633,32 +842,64 @@ def _extract_read_skills_from_tool_calls(
     read_skills: list[dict] = []
     seen_ids: set[str] = set()
     for tc in tool_calls:
-        func = tc.get("function", {})
-        name = (func.get("name") or "").strip()
-        if name.lower() not in ("read", "file_read", "read_file", "readfile"):
+        tool_name, skill_paths = _extract_skill_paths_from_tool_call(tc)
+        normalized = tool_name.lower()
+        if normalized in _HERMES_SKILL_READ_TOOL_NAMES:
+            _, skill_name = _extract_hermes_skill_name_from_tool_call(tc)
+            skill_ref = _resolve_skill_reference_by_name(skill_name, skill_path_map)
+            dedupe_key = skill_ref.get("skill_id") or skill_ref.get("skill_name")
+            if dedupe_key and dedupe_key not in seen_ids:
+                read_skills.append(skill_ref)
+                seen_ids.add(dedupe_key)
             continue
-        try:
-            args = json.loads(func.get("arguments", "{}"))
-        except Exception:
+        if normalized not in _READ_TOOL_NAMES:
             continue
-        path = str(args.get("path") or args.get("file") or "")
-        if not path.endswith("SKILL.md"):
-            continue
-
-        real_path = os.path.realpath(path) if path else ""
-        skill_info = skill_path_map.get(real_path) or skill_path_map.get(path)
-
-        if skill_info:
-            sid = skill_info["skill_id"]
-            if sid not in seen_ids:
-                read_skills.append(dict(skill_info))
-                seen_ids.add(sid)
-        elif path not in seen_ids:
-            dir_name = os.path.basename(os.path.dirname(path))
-            read_skills.append({"skill_id": "", "skill_name": dir_name})
-            seen_ids.add(path)
+        for path in skill_paths:
+            skill_ref = _resolve_skill_reference(path, skill_path_map)
+            dedupe_key = skill_ref.get("skill_id") or skill_ref.get("path") or skill_ref.get("skill_name")
+            if not dedupe_key or dedupe_key in seen_ids:
+                continue
+            read_skills.append(skill_ref)
+            seen_ids.add(dedupe_key)
 
     return read_skills
+
+
+def _extract_modified_skills_from_tool_calls(
+    tool_calls: list[dict],
+    skill_path_map: dict[str, dict[str, str]],
+) -> list[dict]:
+    """Identify SKILL.md files the model attempted to write or update."""
+    modified_skills: list[dict] = []
+    seen_ids: set[str] = set()
+    for tc in tool_calls:
+        tool_name, skill_paths = _extract_skill_paths_from_tool_call(tc)
+        normalized = tool_name.lower()
+        if normalized in _READ_TOOL_NAMES:
+            continue
+        if normalized in _HERMES_SKILL_WRITE_TOOL_NAMES:
+            _, skill_name = _extract_hermes_skill_name_from_tool_call(tc)
+            skill_ref = _resolve_skill_reference_by_name(skill_name, skill_path_map)
+            dedupe_key = skill_ref.get("skill_id") or skill_ref.get("skill_name")
+            if dedupe_key and dedupe_key not in seen_ids:
+                modified_skills.append({**skill_ref, "action": normalized})
+                seen_ids.add(dedupe_key)
+            continue
+        if normalized not in _SKILL_WRITE_TOOL_NAMES and normalized not in _SHELL_TOOL_NAMES:
+            continue
+        for path in skill_paths:
+            skill_ref = _resolve_skill_reference(path, skill_path_map)
+            dedupe_key = skill_ref.get("skill_id") or skill_ref.get("path") or skill_ref.get("skill_name")
+            if not dedupe_key or dedupe_key in seen_ids:
+                continue
+            modified_skills.append(
+                {
+                    **skill_ref,
+                    "action": "shell" if normalized in _SHELL_TOOL_NAMES else normalized,
+                }
+            )
+            seen_ids.add(dedupe_key)
+    return modified_skills
 
 
 def _merge_tool_error_info(
@@ -1724,10 +1965,11 @@ class SkillClawAPIServer:
             if self.skill_manager:
                 self.skill_manager._save_stats()
             turns = self._session_turns.pop(session_id, [])
+            modified_skill_names = _extract_modified_skill_names(turns)
             if turns and self.config.sharing_enabled:
                 self._safe_create_task(self._upload_session_data(session_id, turns))
             if self.config.sharing_enabled:
-                self._safe_create_task(self._pull_skills_from_cloud())
+                self._safe_create_task(self._pull_skills_from_cloud(skip_names=modified_skill_names))
             self._session_last_active.pop(session_id, None)
             for key, meta in list(self._tui_session_meta.items()):
                 if isinstance(meta, dict) and meta.get("session_id") == session_id:
@@ -2089,12 +2331,21 @@ class SkillClawAPIServer:
             read_skills = _extract_read_skills_from_tool_calls(
                 tool_calls, skill_path_map,
             )
+            modified_skills = _extract_modified_skills_from_tool_calls(
+                tool_calls, skill_path_map,
+            )
             tool_summaries = _build_tool_summaries(tool_calls)
             if read_skills:
                 logger.info(
                     "[SkillManager] model read %d skill(s): %s",
                     len(read_skills),
                     ", ".join(r.get("skill_name", "?") for r in read_skills),
+                )
+            if modified_skills:
+                logger.info(
+                    "[SkillManager] model modified %d skill(s): %s",
+                    len(modified_skills),
+                    ", ".join(r.get("skill_name", "?") for r in modified_skills),
                 )
 
             user_instruction = _extract_last_user_instruction(messages)
@@ -2120,6 +2371,7 @@ class SkillClawAPIServer:
                     "reasoning_content": reasoning or None,
                     "tool_calls": tool_calls,
                     "read_skills": read_skills,
+                    "modified_skills": modified_skills,
                     "tool_results": tool_summaries,
                     "tool_results_raw": [],
                     "tool_observations": [],
@@ -2189,6 +2441,7 @@ class SkillClawAPIServer:
                 "reasoning_content": reasoning or None,
                 "tool_calls": tool_calls,
                 "read_skills": read_skills,
+                "modified_skills": modified_skills,
                 "tool_results": tool_summaries,
                 "tool_results_raw": [],
                 "tool_observations": [],
@@ -2441,7 +2694,7 @@ class SkillClawAPIServer:
     # Skill pull (cloud -> local)                                          #
     # ------------------------------------------------------------------ #
 
-    async def _pull_skills_from_cloud(self) -> None:
+    async def _pull_skills_from_cloud(self, skip_names: Optional[set[str]] = None) -> None:
         """Pull latest skills from cloud storage and reload the skill manager.
 
         This is a *read-only* operation — local skills are never pushed
@@ -2450,7 +2703,7 @@ class SkillClawAPIServer:
         try:
             from .skill_hub import SkillHub
             hub = SkillHub.from_config(self.config)
-            pull_result = hub.pull_skills(self.config.skills_dir)
+            pull_result = hub.pull_skills(self.config.skills_dir, skip_names=skip_names)
             logger.info(
                 "[SkillHub] skill pull: %d downloaded, %d unchanged, %d deleted",
                 pull_result["downloaded"], pull_result["skipped"], pull_result.get("deleted", 0),
@@ -2536,6 +2789,11 @@ class SkillClawAPIServer:
         """
         if not self.skill_manager:
             return messages, []
+
+        try:
+            self.skill_manager.refresh_if_changed()
+        except Exception as e:
+            logger.warning("[SkillManager] failed to refresh local skills: %s", e)
 
         skill_text = self.skill_manager.build_injection_prompt(
             max_chars=getattr(self.config, "max_skills_prompt_chars", 30_000),

--- a/skillclaw/claw_adapter.py
+++ b/skillclaw/claw_adapter.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import platform
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -35,6 +36,10 @@ if TYPE_CHECKING:
     from .config import SkillClawConfig
 
 logger = logging.getLogger(__name__)
+_LEGACY_SKILLCLAW_SKILLS_DIR = Path.home() / ".skillclaw" / "skills"
+_HERMES_HOME = Path.home() / ".hermes"
+_HERMES_SKILLS_DIR = _HERMES_HOME / "skills"
+_HERMES_BACKUP_DIR = Path.home() / ".skillclaw" / "backups" / "hermes"
 
 
 # ------------------------------------------------------------------ #
@@ -154,7 +159,7 @@ def _write_yaml_mapping_atomic(path: Path, data: dict, label: str) -> None:
             delete=False,
         ) as handle:
             tmp_path = Path(handle.name)
-            yaml.safe_dump(data, handle, sort_keys=False, allow_unicode=True)
+            handle.write(_yaml_mapping_to_text(data))
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp_path, path)
@@ -164,6 +169,73 @@ def _write_yaml_mapping_atomic(path: Path, data: dict, label: str) -> None:
     finally:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
+
+
+def _yaml_mapping_to_text(data: dict) -> str:
+    return yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+
+
+def _write_text_atomic(path: Path, text: str, label: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as handle:
+            tmp_path = Path(handle.name)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        logger.info("[ClawAdapter] %s updated: %s", label, path)
+    except Exception as e:
+        logger.error("[ClawAdapter] Failed to write %s %s: %s", label, path, e)
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
+
+def _backup_hermes_config_if_changed(config_path: Path, new_text: str) -> Path | None:
+    """Save the current Hermes config before overwriting it, if it changed."""
+    if not config_path.exists():
+        return None
+
+    try:
+        current_text = config_path.read_text(encoding="utf-8")
+    except Exception as e:
+        logger.warning("[ClawAdapter] Failed to read Hermes config for backup: %s", e)
+        return None
+
+    if current_text == new_text:
+        return None
+
+    _HERMES_BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    backup_path = _HERMES_BACKUP_DIR / f"config.{timestamp}.yaml"
+    latest_path = _HERMES_BACKUP_DIR / "config.latest.yaml"
+    try:
+        backup_path.write_text(current_text, encoding="utf-8")
+        latest_path.write_text(current_text, encoding="utf-8")
+        logger.info("[ClawAdapter] Hermes config backup saved: %s", backup_path)
+        return backup_path
+    except Exception as e:
+        logger.warning("[ClawAdapter] Failed to save Hermes config backup: %s", e)
+        return None
+
+
+def _latest_hermes_backup_path() -> Path | None:
+    latest_path = _HERMES_BACKUP_DIR / "config.latest.yaml"
+    if latest_path.exists():
+        return latest_path
+    if not _HERMES_BACKUP_DIR.is_dir():
+        return None
+    backups = sorted(_HERMES_BACKUP_DIR.glob("config.*.yaml"))
+    return backups[-1] if backups else None
 
 
 def _write_json_mapping_atomic(path: Path, data: dict, label: str) -> None:
@@ -195,10 +267,11 @@ def _write_json_mapping_atomic(path: Path, data: dict, label: str) -> None:
 
 def _configure_hermes(cfg: "SkillClawConfig") -> None:
     """Auto-configure Hermes to route model traffic through SkillClaw."""
-    config_path = Path.home() / ".hermes" / "config.yaml"
+    config_path = _HERMES_HOME / "config.yaml"
     model_id = cfg.served_model_name or cfg.llm_model_id or "skillclaw-model"
     api_key = cfg.proxy_api_key or "skillclaw"
     base_url = f"http://127.0.0.1:{cfg.proxy_port}/v1"
+    _prepare_hermes_skills_dir(cfg)
 
     data = _load_yaml_mapping(config_path, "Hermes")
     model = data.get("model")
@@ -213,7 +286,134 @@ def _configure_hermes(cfg: "SkillClawConfig") -> None:
     model["api_mode"] = ""
 
     data["model"] = model
+    _backup_hermes_config_if_changed(config_path, _yaml_mapping_to_text(data))
     _write_yaml_mapping_atomic(config_path, data, "Hermes")
+
+
+def inspect_hermes_config(cfg: "SkillClawConfig") -> dict[str, object]:
+    """Return a diagnostic snapshot of the local Hermes integration state."""
+    config_path = _HERMES_HOME / "config.yaml"
+    expected_model = cfg.served_model_name or cfg.llm_model_id or "skillclaw-model"
+    expected_base_url = f"http://127.0.0.1:{cfg.proxy_port}/v1"
+    expected_api_key = cfg.proxy_api_key or "skillclaw"
+    expected_skills_dir = Path(str(getattr(cfg, "skills_dir", "") or _HERMES_SKILLS_DIR)).expanduser()
+
+    data = _load_yaml_mapping(config_path, "Hermes")
+    model = data.get("model") if isinstance(data, dict) else {}
+    if not isinstance(model, dict):
+        model = {"default": model} if isinstance(model, str) and model else {}
+
+    configured_provider = str(model.get("provider", "") or "")
+    configured_base_url = str(model.get("base_url", "") or "")
+    configured_default = str(model.get("default", "") or "")
+    configured_api_key = str(model.get("api_key", "") or "")
+
+    backup_path = _latest_hermes_backup_path()
+    proxy_match = (
+        configured_provider == "custom"
+        and configured_base_url == expected_base_url
+        and configured_default == expected_model
+        and configured_api_key == expected_api_key
+    )
+    legacy_present = _LEGACY_SKILLCLAW_SKILLS_DIR.is_dir()
+    uses_default_skills_dir = expected_skills_dir == _HERMES_SKILLS_DIR
+    issues: list[str] = []
+    notes: list[str] = [
+        "This integration only rewrites Hermes-local config and does not touch other claw adapters.",
+        "Hermes session capture still relies on explicit session headers when available, with proxy-side heuristics as the fallback.",
+    ]
+    next_steps: list[str] = []
+
+    if not config_path.exists():
+        issues.append("Hermes config is missing: ~/.hermes/config.yaml")
+    if not proxy_match:
+        issues.append("Hermes model routing is not pointing at the local SkillClaw proxy.")
+        next_steps.append("Start SkillClaw once so it can rewrite ~/.hermes/config.yaml.")
+    if not expected_skills_dir.is_dir():
+        issues.append(f"Hermes skills directory is missing: {expected_skills_dir}")
+        next_steps.append(f"Create or prepare the Hermes skills directory: {expected_skills_dir}")
+    if legacy_present:
+        notes.append(
+            f"Legacy SkillClaw skills were found at {_LEGACY_SKILLCLAW_SKILLS_DIR}; missing skills are copied into the Hermes library on startup."
+        )
+    if not backup_path:
+        next_steps.append("Run SkillClaw once before relying on `skillclaw restore hermes`, so a backup can be created.")
+
+    return {
+        "status": "ok" if not issues else "warning",
+        "config_path": str(config_path),
+        "config_exists": config_path.exists(),
+        "integration_scope": "hermes-only",
+        "expected_model": expected_model,
+        "expected_base_url": expected_base_url,
+        "configured_provider": configured_provider or "(unset)",
+        "configured_base_url": configured_base_url or "(unset)",
+        "configured_model": configured_default or "(unset)",
+        "proxy_match": proxy_match,
+        "expected_skills_dir": str(expected_skills_dir),
+        "skills_dir_exists": expected_skills_dir.is_dir(),
+        "skills_dir_mode": "hermes-default" if uses_default_skills_dir else "custom",
+        "legacy_skillclaw_skills_dir": str(_LEGACY_SKILLCLAW_SKILLS_DIR),
+        "legacy_skillclaw_skills_present": legacy_present,
+        "latest_backup": str(backup_path) if backup_path else "(none)",
+        "session_boundary_mode": "explicit headers if provided, proxy heuristics otherwise",
+        "issues": issues,
+        "notes": notes,
+        "next_steps": next_steps,
+    }
+
+
+def restore_hermes_config(backup_path: Path | None = None) -> dict[str, str]:
+    """Restore ~/.hermes/config.yaml from the latest or a specified backup."""
+    source = Path(backup_path).expanduser() if backup_path is not None else _latest_hermes_backup_path()
+    if source is None or not source.exists():
+        raise FileNotFoundError("No Hermes backup found")
+
+    text = source.read_text(encoding="utf-8")
+    target = _HERMES_HOME / "config.yaml"
+    _write_text_atomic(target, text, "Hermes config restore")
+    return {"source": str(source), "target": str(target)}
+
+
+def _prepare_hermes_skills_dir(cfg: "SkillClawConfig") -> None:
+    """Prepare the Hermes-local skill directory without touching other agents."""
+    target_dir = Path(str(getattr(cfg, "skills_dir", "") or _HERMES_SKILLS_DIR)).expanduser()
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    if target_dir != _HERMES_SKILLS_DIR:
+        logger.info(
+            "[ClawAdapter] Hermes uses custom skills dir: %s",
+            target_dir,
+        )
+        return
+
+    if not _LEGACY_SKILLCLAW_SKILLS_DIR.is_dir():
+        return
+
+    migrated = _copy_missing_skill_dirs(_LEGACY_SKILLCLAW_SKILLS_DIR, target_dir)
+    if migrated > 0:
+        logger.info(
+            "[ClawAdapter] migrated %d legacy SkillClaw skill(s) into Hermes skills dir",
+            migrated,
+        )
+
+
+def _copy_missing_skill_dirs(src_root: Path, dst_root: Path) -> int:
+    """Copy only skill folders that do not already exist in the destination."""
+    copied = 0
+    for entry in sorted(src_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        src_skill_md = entry / "SKILL.md"
+        if not src_skill_md.is_file():
+            continue
+        dst_dir = dst_root / entry.name
+        dst_skill_md = dst_dir / "SKILL.md"
+        if dst_skill_md.exists():
+            continue
+        shutil.copytree(entry, dst_dir)
+        copied += 1
+    return copied
 
 
 # ------------------------------------------------------------------ #

--- a/skillclaw/cli.py
+++ b/skillclaw/cli.py
@@ -54,6 +54,52 @@ def _clear_pid_if_matches(pid: int):
     runtime_state.clear_pid_if_matches(pid)
 
 
+def _echo_report(report: dict[str, object]) -> None:
+    ordered_keys = [
+        "status",
+        "integration_scope",
+        "config_path",
+        "config_exists",
+        "expected_model",
+        "configured_model",
+        "expected_base_url",
+        "configured_base_url",
+        "configured_provider",
+        "proxy_match",
+        "expected_skills_dir",
+        "skills_dir_exists",
+        "skills_dir_mode",
+        "legacy_skillclaw_skills_dir",
+        "legacy_skillclaw_skills_present",
+        "latest_backup",
+        "session_boundary_mode",
+    ]
+    list_keys = {"issues", "notes", "next_steps"}
+    emitted: set[str] = set()
+
+    for key in ordered_keys:
+        if key not in report:
+            continue
+        click.echo(f"{key}: {report[key]}")
+        emitted.add(key)
+
+    for key, value in report.items():
+        if key in emitted or key in list_keys:
+            continue
+        click.echo(f"{key}: {value}")
+
+    for key in ("issues", "notes", "next_steps"):
+        value = report.get(key)
+        if not isinstance(value, list):
+            continue
+        click.echo(f"{key}:")
+        if not value:
+            click.echo("  (none)")
+            continue
+        for item in value:
+            click.echo(f"  - {item}")
+
+
 def _healthz_ready(port: int, timeout: float = 0.5) -> bool:
     import urllib.request
 
@@ -357,6 +403,53 @@ def config_cmd(key_or_action: str, value: str | None):
 
     cs.set(key_or_action, value)
     click.echo(f"Set {key_or_action} = {cs.get(key_or_action)}")
+
+
+@skillclaw.group()
+def doctor():
+    """Integration diagnostics."""
+
+
+@doctor.command(name="hermes")
+def doctor_hermes():
+    """Inspect the local Hermes integration state."""
+    from .claw_adapter import inspect_hermes_config
+
+    cs = ConfigStore()
+    if not cs.exists():
+        raise click.ClickException("No config file found. Run 'skillclaw setup' first.")
+
+    report = inspect_hermes_config(cs.to_skillclaw_config())
+    _echo_report(report)
+
+
+@skillclaw.group()
+def restore():
+    """Restore agent integration state from backups."""
+
+
+@restore.command(name="hermes")
+@click.option(
+    "--backup",
+    "backup_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    default=None,
+    help="Restore from a specific backup file instead of the latest Hermes backup.",
+)
+def restore_hermes(backup_path: str | None):
+    """Restore ~/.hermes/config.yaml from a saved backup."""
+    from .claw_adapter import restore_hermes_config
+
+    try:
+        result = restore_hermes_config(
+            Path(backup_path).expanduser() if backup_path else None
+        )
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from None
+
+    click.echo(
+        f"Restored Hermes config: {result['target']} <- {result['source']}"
+    )
 
 
 @skillclaw.group()

--- a/skillclaw/config_store.py
+++ b/skillclaw/config_store.py
@@ -14,6 +14,8 @@ from .config import SkillClawConfig
 
 CONFIG_DIR = Path.home() / ".skillclaw"
 CONFIG_FILE = CONFIG_DIR / "config.yaml"
+_DEFAULT_SKILLS_DIR = CONFIG_DIR / "skills"
+_DEFAULT_HERMES_SKILLS_DIR = Path.home() / ".hermes" / "skills"
 
 _DEFAULTS: dict = {
     "llm": {
@@ -32,7 +34,7 @@ _DEFAULTS: dict = {
     "configure_openclaw": True,
     "skills": {
         "enabled": True,
-        "dir": str(Path.home() / ".skillclaw" / "skills"),
+        "dir": str(_DEFAULT_SKILLS_DIR),
         "retrieval_mode": "template",
         "top_k": 6,
     },
@@ -133,6 +135,33 @@ def _normalize_validation_mode(value: Any) -> str:
     return "replay"
 
 
+def default_skills_dir_for_claw(claw_type: str) -> Path:
+    """Return the default local skills directory for the selected agent."""
+    normalized = str(claw_type or "").strip().lower()
+    if normalized == "hermes":
+        return _DEFAULT_HERMES_SKILLS_DIR
+    return _DEFAULT_SKILLS_DIR
+
+
+def resolve_skills_dir(skills_dir: Any, *, claw_type: str) -> str:
+    """Normalize a configured skills dir, applying Hermes-aware defaults.
+
+    Existing configs that still point at the old generic default are treated as
+    "unset" when Hermes is selected so SkillClaw follows Hermes' own skill
+    library by default.
+    """
+    raw = str(skills_dir or "").strip()
+    generic_default = _DEFAULT_SKILLS_DIR.expanduser()
+
+    if raw:
+        expanded = Path(raw).expanduser()
+        if str(claw_type or "").strip().lower() == "hermes" and expanded == generic_default:
+            return str(default_skills_dir_for_claw("hermes"))
+        return str(expanded)
+
+    return str(default_skills_dir_for_claw(claw_type))
+
+
 def _default_served_model_name(llm_model_id: str) -> str:
     """Return a safe proxy-facing model name for agent integrations.
 
@@ -229,8 +258,9 @@ class ConfigStore:
         prm_model = str(prm.get("model", "") or llm_model_id or "gpt-5.2")
         prm_api_key = str(prm.get("api_key", "") or llm_api_key)
 
-        skills_dir = str(
-            Path(skills.get("dir", str(CONFIG_DIR / "skills"))).expanduser()
+        skills_dir = resolve_skills_dir(
+            skills.get("dir", str(_DEFAULT_SKILLS_DIR)),
+            claw_type=raw_claw_type,
         )
 
         return SkillClawConfig(
@@ -301,8 +331,13 @@ class ConfigStore:
         llm = data.get("llm", {})
         skills = data.get("skills", {})
         prm = data.get("prm", {})
+        claw_type = str(data.get("claw_type", "openclaw") or "openclaw")
+        effective_skills_dir = resolve_skills_dir(
+            skills.get("dir", str(_DEFAULT_SKILLS_DIR)),
+            claw_type=claw_type,
+        )
         lines = [
-            f"claw_type:       {data.get('claw_type', 'openclaw')}",
+            f"claw_type:       {claw_type}",
             f"llm.provider:    {llm.get('provider', '?')}",
             f"llm.model_id:    {llm.get('model_id', '?')}",
             f"llm.api_base:    {llm.get('api_base', '—') if llm.get('provider') != 'bedrock' else '(n/a)'}",
@@ -314,7 +349,7 @@ class ConfigStore:
             ] if llm.get('provider') == 'openrouter' else []),
             f"proxy.port:      {data.get('proxy', {}).get('port', 30000)}",
             f"skills.enabled:  {skills.get('enabled', True)}",
-            f"skills.dir:      {skills.get('dir', '?')}",
+            f"skills.dir:      {effective_skills_dir}",
             f"prm.enabled:     {prm.get('enabled', False)}",
         ]
         sharing = data.get("sharing", {})

--- a/skillclaw/setup_wizard.py
+++ b/skillclaw/setup_wizard.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .claw_adapter import CLAW_TYPES
-from .config_store import CONFIG_DIR, ConfigStore
+from .config_store import CONFIG_DIR, ConfigStore, resolve_skills_dir
 
 _PROVIDER_PRESETS = {
     "kimi": {
@@ -199,14 +199,23 @@ class SetupWizard:
         # ---- Skills ----
         print("\n--- Skills Configuration ---")
         current_skills = existing.get("skills", {})
+        default_skills_dir = resolve_skills_dir(
+            current_skills.get("dir", str(CONFIG_DIR / "skills")),
+            claw_type=claw_type,
+        )
+        if claw_type == "hermes":
+            print(
+                "Hermes shares its local skill library with SkillClaw by default.\n"
+                f"Recommended directory: {default_skills_dir}"
+            )
         skills_enabled = _prompt_bool(
             "Enable skill injection", default=current_skills.get("enabled", True)
         )
-        default_skills_dir = str(CONFIG_DIR / "skills")
         skills_dir = _prompt(
             "Skills directory",
-            default=current_skills.get("dir", default_skills_dir),
+            default=default_skills_dir,
         )
+        skills_dir = str(Path(skills_dir).expanduser())
 
         # ---- PRM ----
         print("\n--- PRM (Quality Scoring) ---")

--- a/skillclaw/skill_hub.py
+++ b/skillclaw/skill_hub.py
@@ -20,8 +20,9 @@ import json
 import logging
 import os
 import shutil
+import glob
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, Collection, Optional
 
 from .object_store import build_object_store, is_not_found_error
 
@@ -34,6 +35,28 @@ def _compute_sha256(path: str) -> str:
         for chunk in iter(lambda: f.read(8192), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def _is_hermes_skill_root(skills_dir: str) -> bool:
+    return os.path.realpath(skills_dir) == os.path.realpath(
+        os.path.join(os.path.expanduser("~"), ".hermes", "skills")
+    )
+
+
+def _skill_dir_for_root(skills_dir: str, skill_name: str, category: str = "general") -> str:
+    if _is_hermes_skill_root(skills_dir) and category and category != "general":
+        return os.path.join(skills_dir, category, skill_name)
+    return os.path.join(skills_dir, skill_name)
+
+
+def _category_from_skill_path(skills_dir: str, skill_md_path: str) -> str:
+    if not _is_hermes_skill_root(skills_dir):
+        return "general"
+    rel = os.path.relpath(skill_md_path, skills_dir)
+    parts = rel.split(os.sep)
+    if len(parts) >= 3:
+        return str(parts[0] or "general")
+    return "general"
 
 
 class SkillHub:
@@ -164,9 +187,10 @@ class SkillHub:
 
         Returns {"uploaded": N, "skipped": M, "filtered": F, "total_local": T}.
         """
-        import glob
-
-        paths = sorted(glob.glob(os.path.join(skills_dir, "*", "SKILL.md")))
+        if _is_hermes_skill_root(skills_dir):
+            paths = sorted(glob.glob(os.path.join(skills_dir, "**", "SKILL.md"), recursive=True))
+        else:
+            paths = sorted(glob.glob(os.path.join(skills_dir, "*", "SKILL.md")))
         if not paths:
             logger.info("[SkillHub] no local skills to push")
             return {"uploaded": 0, "skipped": 0, "filtered": 0, "total_local": 0}
@@ -213,6 +237,7 @@ class SkillHub:
                 "uploaded_at": datetime.now(timezone.utc).isoformat(),
             }
             self._enrich_manifest_entry(manifest[skill_name], path)
+            manifest[skill_name].setdefault("category", _category_from_skill_path(skills_dir, path))
             uploaded += 1
             logger.info("[SkillHub] pushed skill: %s", skill_name)
 
@@ -265,18 +290,75 @@ class SkillHub:
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    def _list_local_skills(skills_dir: str) -> dict[str, str]:
-        """Return {skill_name: skill_dir} for local `<name>/SKILL.md` entries."""
-        out: dict[str, str] = {}
+    def _list_local_skill_dirs(skills_dir: str) -> dict[str, list[str]]:
+        """Return {skill_name: [skill_dir, ...]} for local `<name>/SKILL.md` entries."""
+        out: dict[str, list[str]] = {}
         if not os.path.isdir(skills_dir):
+            return out
+        if _is_hermes_skill_root(skills_dir):
+            for path in sorted(glob.glob(os.path.join(skills_dir, "**", "SKILL.md"), recursive=True)):
+                skill_dir = os.path.dirname(path)
+                name = os.path.basename(skill_dir)
+                out.setdefault(name, []).append(skill_dir)
             return out
         for entry in os.scandir(skills_dir):
             if not entry.is_dir():
                 continue
             skill_md = os.path.join(entry.path, "SKILL.md")
             if os.path.isfile(skill_md):
-                out[entry.name] = entry.path
+                out.setdefault(entry.name, []).append(entry.path)
         return out
+
+    @classmethod
+    def _list_local_skills(cls, skills_dir: str) -> dict[str, str]:
+        """Return {skill_name: skill_dir} for local `<name>/SKILL.md` entries."""
+        grouped = cls._list_local_skill_dirs(skills_dir)
+        return {name: dirs[-1] for name, dirs in grouped.items() if dirs}
+
+    @staticmethod
+    def _resolve_pull_target_dir(
+        skills_dir: str,
+        skill_name: str,
+        category: str,
+        local_dirs_by_name: dict[str, list[str]],
+    ) -> str:
+        target = _skill_dir_for_root(skills_dir, skill_name, category)
+        if not _is_hermes_skill_root(skills_dir):
+            return target
+
+        existing_dirs = local_dirs_by_name.get(skill_name) or []
+        if not existing_dirs:
+            return target
+
+        if str(category or "general").strip() == "general":
+            nested = [
+                path for path in existing_dirs
+                if len(os.path.relpath(path, skills_dir).split(os.sep)) >= 2
+            ]
+            if len(nested) == 1:
+                return nested[0]
+
+        target_real = os.path.realpath(target)
+        existing_real = [os.path.realpath(path) for path in existing_dirs]
+        if target_real in existing_real:
+            return target
+
+        return target
+
+    @staticmethod
+    def _remove_duplicate_local_skill_dirs(
+        skill_name: str,
+        keep_dir: str,
+        local_dirs_by_name: dict[str, list[str]],
+    ) -> None:
+        keep_real = os.path.realpath(keep_dir)
+        for skill_dir in local_dirs_by_name.get(skill_name) or []:
+            if os.path.realpath(skill_dir) == keep_real:
+                continue
+            if not os.path.isdir(skill_dir):
+                continue
+            shutil.rmtree(skill_dir)
+            logger.info("[SkillHub] removed duplicate local skill dir: %s", skill_dir)
 
     @staticmethod
     def _prune_backups(backup_root: str, prefix: str, keep: int = 3) -> None:
@@ -296,7 +378,12 @@ class SkillHub:
             except Exception:
                 pass
 
-    def pull_skills(self, skills_dir: str, mirror: bool = True) -> dict[str, Any]:
+    def pull_skills(
+        self,
+        skills_dir: str,
+        mirror: bool = True,
+        skip_names: Optional[Collection[str]] = None,
+    ) -> dict[str, Any]:
         """Mirror cloud skills to local directory with backup + rollback safety.
 
         Parameters
@@ -308,6 +395,8 @@ class SkillHub:
             not present in remote manifest are deleted. When ``False``, perform
             incremental pull only (download/update remote skills, never delete
             local extras).
+        skip_names:
+            Skill names to preserve from local disk during this pull.
 
         Returns:
             {
@@ -320,8 +409,14 @@ class SkillHub:
             }
         """
         os.makedirs(skills_dir, exist_ok=True)
-        local_skills = self._list_local_skills(skills_dir)
+        local_dirs_by_name = self._list_local_skill_dirs(skills_dir)
+        local_skills = {name: dirs[-1] for name, dirs in local_dirs_by_name.items() if dirs}
         manifest = self._load_remote_manifest()
+        skip_set = {
+            str(name or "").strip()
+            for name in (skip_names or [])
+            if str(name or "").strip()
+        }
         if not manifest:
             # Empty/failed manifest is treated as no-op to avoid accidental wipe.
             logger.warning(
@@ -344,14 +439,27 @@ class SkillHub:
 
         if not mirror:
             for name, rec in manifest.items():
-                local_dir = os.path.join(skills_dir, name)
+                category = str(rec.get("category", "general") or "general")
+                local_dir = self._resolve_pull_target_dir(
+                    skills_dir,
+                    name,
+                    category,
+                    local_dirs_by_name,
+                )
                 local_path = os.path.join(local_dir, "SKILL.md")
                 remote_sha = rec.get("sha256", "")
+
+                if name in skip_set and os.path.exists(local_path):
+                    skipped += 1
+                    self._remove_duplicate_local_skill_dirs(name, local_dir, local_dirs_by_name)
+                    logger.info("[SkillHub] preserved local skill during pull: %s", name)
+                    continue
 
                 if os.path.exists(local_path):
                     local_sha = _compute_sha256(local_path)
                     if local_sha == remote_sha:
                         skipped += 1
+                        self._remove_duplicate_local_skill_dirs(name, local_dir, local_dirs_by_name)
                         continue
 
                 try:
@@ -365,6 +473,7 @@ class SkillHub:
                 with open(local_path, "wb") as f:
                     f.write(content)
                 downloaded += 1
+                self._remove_duplicate_local_skill_dirs(name, local_dir, local_dirs_by_name)
                 logger.info("[SkillHub] pulled skill: %s", name)
 
             logger.info(
@@ -403,14 +512,33 @@ class SkillHub:
             }
 
         os.makedirs(staging_dir, exist_ok=True)
+        resolved_targets: dict[str, str] = {}
 
         try:
             for name, rec in manifest.items():
-                local_path = os.path.join(skills_dir, name, "SKILL.md")
-                staged_dir = os.path.join(staging_dir, name)
+                category = str(rec.get("category", "general") or "general")
+                target_dir = self._resolve_pull_target_dir(
+                    skills_dir,
+                    name,
+                    category,
+                    local_dirs_by_name,
+                )
+                resolved_targets[name] = target_dir
+                local_path = os.path.join(target_dir, "SKILL.md")
+                staged_dir = os.path.join(staging_dir, os.path.relpath(target_dir, skills_dir))
                 staged_path = os.path.join(staged_dir, "SKILL.md")
                 remote_sha = rec.get("sha256", "")
                 content: bytes
+
+                if name in skip_set and os.path.exists(local_path):
+                    with open(local_path, "rb") as f:
+                        content = f.read()
+                    skipped += 1
+                    os.makedirs(staged_dir, exist_ok=True)
+                    with open(staged_path, "wb") as f:
+                        f.write(content)
+                    logger.info("[SkillHub] preserved local skill during pull: %s", name)
+                    continue
 
                 if os.path.exists(local_path):
                     local_sha = _compute_sha256(local_path)
@@ -438,15 +566,24 @@ class SkillHub:
             remote_names = set(manifest.keys())
             local_names = set(local_skills.keys())
             for stale in sorted(local_names - remote_names):
-                shutil.rmtree(os.path.join(skills_dir, stale), ignore_errors=False)
+                shutil.rmtree(local_skills[stale], ignore_errors=False)
                 deleted += 1
 
             for name in sorted(remote_names):
-                src_dir = os.path.join(staging_dir, name)
-                dst_dir = os.path.join(skills_dir, name)
+                rec = manifest.get(name, {})
+                category = str(rec.get("category", "general") or "general")
+                dst_dir = resolved_targets.get(name) or self._resolve_pull_target_dir(
+                    skills_dir,
+                    name,
+                    category,
+                    local_dirs_by_name,
+                )
+                src_dir = os.path.join(staging_dir, os.path.relpath(dst_dir, skills_dir))
                 if os.path.isdir(dst_dir):
                     shutil.rmtree(dst_dir)
+                os.makedirs(os.path.dirname(dst_dir), exist_ok=True)
                 shutil.move(src_dir, dst_dir)
+                self._remove_duplicate_local_skill_dirs(name, dst_dir, local_dirs_by_name)
 
         except Exception as e:
             logger.warning("[SkillHub] mirror pull failed, restoring backup: %s", e)

--- a/skillclaw/skill_manager.py
+++ b/skillclaw/skill_manager.py
@@ -187,12 +187,12 @@ class SkillManager:
         self._embedding_model = None
         self._skill_embeddings_cache: Optional[Dict] = None
 
-        # Monotonically-increasing counter. Incremented each time new skills are
-        # successfully added via add_skills(). This lets callers drop stale
-        # pre-evolution feedback snapshots after a skill library change.
+        # Monotonically-increasing counter. Incremented whenever the local
+        # skill library changes so callers can drop stale snapshots.
         self.generation: int = 0
 
         self.skills = self._load_skills()
+        self._skills_fingerprint = self._compute_skills_fingerprint()
         self._stats = self._load_stats()
         self._stats_dirty = 0
 
@@ -288,7 +288,7 @@ class SkillManager:
         """Scan skills_dir for */SKILL.md files and parse each into a flat collection."""
         result: Dict[str, Any] = {"all_skills": []}
 
-        paths = sorted(glob.glob(os.path.join(self._skills_dir, "*", "SKILL.md")))
+        paths = self._skill_md_paths()
         if not paths:
             logger.warning("[SkillManager] no SKILL.md files found in %s", self._skills_dir)
             return result
@@ -301,15 +301,64 @@ class SkillManager:
 
         return result
 
+    def _skill_md_paths(self) -> list[str]:
+        if self._is_hermes_skill_root():
+            pattern = os.path.join(self._skills_dir, "**", "SKILL.md")
+            return sorted(glob.glob(pattern, recursive=True))
+        pattern = os.path.join(self._skills_dir, "*", "SKILL.md")
+        return sorted(glob.glob(pattern))
+
+    def _compute_skills_fingerprint(self) -> tuple[tuple[str, int, int], ...]:
+        fingerprint: list[tuple[str, int, int]] = []
+        for path in self._skill_md_paths():
+            try:
+                stat = os.stat(path)
+            except OSError:
+                continue
+            fingerprint.append(
+                (
+                    os.path.realpath(path),
+                    int(stat.st_mtime_ns),
+                    int(stat.st_size),
+                )
+            )
+        return tuple(fingerprint)
+
+    def _is_hermes_skill_root(self) -> bool:
+        return os.path.realpath(self._skills_dir) == os.path.realpath(
+            os.path.join(os.path.expanduser("~"), ".hermes", "skills")
+        )
+
+    def _skill_dir_path(self, skill: dict) -> str:
+        name = str(skill.get("name", "unknown") or "unknown").strip()
+        category = str(skill.get("category", "general") or "general").strip()
+        if self._is_hermes_skill_root() and category and category != "general":
+            return os.path.join(self._skills_dir, category, name)
+        return os.path.join(self._skills_dir, name)
+
+    def _skill_md_path(self, skill: dict) -> str:
+        return os.path.join(self._skill_dir_path(skill), "SKILL.md")
+
     def reload(self) -> None:
         """Re-scan the skills directory and rebuild the internal skill bank."""
         self._save_stats()
         self.skills = self._load_skills()
+        self._skills_fingerprint = self._compute_skills_fingerprint()
         self._stats = self._load_stats()
         self._skill_embeddings_cache = None
         if self.retrieval_mode == "embedding":
             self._compute_skill_embeddings()
         logger.info("[SkillManager] reloaded skills from %s", self._skills_dir)
+
+    def refresh_if_changed(self) -> bool:
+        """Reload skills if the on-disk skill library changed externally."""
+        current = self._compute_skills_fingerprint()
+        if current == self._skills_fingerprint:
+            return False
+        self.reload()
+        self.generation += 1
+        logger.info("[SkillManager] detected local skill changes; refreshed library")
+        return True
 
     # ------------------------------------------------------------------ #
     # Embedding helpers                                                    #
@@ -638,14 +687,13 @@ class SkillManager:
         if "id" not in clean_skill:
             clean_skill["id"] = hashlib.sha256(name.encode()).hexdigest()[:12]
         if "file_path" not in clean_skill:
-            clean_skill["file_path"] = os.path.realpath(
-                os.path.join(self._skills_dir, name, "SKILL.md")
-            )
+            clean_skill["file_path"] = os.path.realpath(self._skill_md_path(clean_skill))
         clean_skill["category"] = str(clean_skill.get("category", "general") or "general").strip()
         self.skills.setdefault("all_skills", []).append(clean_skill)
 
         self._skill_embeddings_cache = None
         self._write_skill_md(clean_skill)
+        self._skills_fingerprint = self._compute_skills_fingerprint()
         logger.info("[SkillManager] added skill: %s", name)
         return True
 
@@ -731,13 +779,13 @@ class SkillManager:
         existing SKILL.md are preserved in the output.
         """
         name = skill.get("name", "unknown")
-        skill_dir = os.path.join(self._skills_dir, name)
+        skill_dir = self._skill_dir_path(skill)
         canonical = os.path.realpath(skill_dir)
         if not canonical.startswith(os.path.realpath(self._skills_dir) + os.sep):
             logger.warning("[SkillManager] blocked path traversal in skill name: %s", name)
             return
         os.makedirs(skill_dir, exist_ok=True)
-        filepath = os.path.join(skill_dir, "SKILL.md")
+        filepath = self._skill_md_path(skill)
 
         category = skill.get("category", "general")
         content = skill.get("content", "")
@@ -761,6 +809,7 @@ class SkillManager:
         try:
             with open(filepath, "w", encoding="utf-8") as f:
                 f.write(text)
+            skill["file_path"] = os.path.realpath(filepath)
             logger.info("[SkillManager] wrote skill file: %s", filepath)
         except OSError as e:
             logger.warning("[SkillManager] could not write %s: %s", filepath, e)
@@ -775,6 +824,7 @@ class SkillManager:
         all_skills = list(self.skills.get("all_skills", []))
         for skill in all_skills:
             self._write_skill_md(skill)
+        self._skills_fingerprint = self._compute_skills_fingerprint()
         logger.info("[SkillManager] saved %d skills to %s", len(all_skills), self._skills_dir)
 
     def _get_all_skill_names(self) -> set:


### PR DESCRIPTION
…s overhaul

- Add full Hermes agent integration in claw_adapter (config backup/restore, skill directory management, legacy skill migration)
- Enhance api_server with SKILL.md file tracking from tool calls (read/write/ shell/patch), extracting modified skill names per turn
- Extend skill_hub to support Hermes category-based skill hierarchy and recursive skill discovery
- Add `doctor hermes` and `skills` CLI commands for integration diagnostics and skill management
- Improve evolve_server workflow engine and summarizer pipeline
- Rewrite README with new architecture diagrams (two_loops, multiplier_effect, cross_context SVGs) illustrating single-user and multi-user value props
- Add .gitignore for runtime data (records/, evolve_history.jsonl)

Made-with: Cursor