### PR TITLE
fix: include input_tokens in message_delta events for Anthropic compatibility

### DIFF
--- a/skillclaw/protocols/anthropic_messages.py
+++ b/skillclaw/protocols/anthropic_messages.py
@@ -316,7 +316,10 @@ async def stream_from_openai_result(result: dict[str, Any], model: str) -> Async
         {
             "type": "message_delta",
             "delta": {"stop_reason": stop_reason, "stop_sequence": None},
-            "usage": {"output_tokens": usage.get("completion_tokens", 0)},
+            "usage": {
+                "input_tokens": usage.get("prompt_tokens", 0),
+                "output_tokens": usage.get("completion_tokens", 0),
+            },
         },
     )
     yield sse("message_stop", {"type": "message_stop"})

--- a/skillclaw/protocols/anthropic_messages.py
+++ b/skillclaw/protocols/anthropic_messages.py
@@ -537,7 +537,7 @@ async def stream_from_openai_result(
         {
             "type": "message_delta",
             "delta": {"stop_reason": stop_reason, "stop_sequence": None},
-            "usage": {"output_tokens": anthropic_usage.get("output_tokens", 0)},
+            "usage": {**anthropic_usage},
         },
     )
     yield sse("message_stop", {"type": "message_stop"})

--- a/tests/test_anthropic_messages.py
+++ b/tests/test_anthropic_messages.py
@@ -518,6 +518,30 @@ def test_streaming_openai_tool_calls_use_tool_use_stop_reason_even_if_finish_rea
     )
 
 
+def test_streaming_final_message_delta_usage_includes_input_and_output_tokens():
+    import asyncio
+    import json
+
+    result = {
+        "response": {
+            "id": "chatcmpl_1",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+        }
+    }
+
+    events = asyncio.run(_collect_stream_events(result, "claude-code-test"))
+    parsed = [(name, json.loads(data)) for name, data in events]
+
+    message_delta = next(payload for name, payload in parsed if name == "message_delta")
+    assert message_delta["usage"] == {"input_tokens": 10, "output_tokens": 2}
+
+
 def test_anthropic_system_blocks_preserve_text_and_cache_control():
     body = {
         "model": "claude-code-test",


### PR DESCRIPTION
## Problem

Some Anthropic-compatible clients (e.g., AgentScope/QwenPaw) expect `input_tokens` to be present in the `message_delta` event's usage object. Currently, `stream_from_openai_result` only includes `output_tokens`, which causes `TypeError: '>' not supported between instances of 'NoneType' and 'int'` in frameworks that parse `usage.input_tokens` from the final delta event.

## Solution

Add `input_tokens` to the `usage` dict in the `message_delta` event, matching the value from `message_start`.

### Changed
```python
# Before
"usage": {"output_tokens": usage.get("completion_tokens", 0)},

# After  
"usage": {
    "input_tokens": usage.get("prompt_tokens", 0),
    "output_tokens": usage.get("completion_tokens", 0),
},
```

## Verification

Tested with:
- ✅ Simple streaming & non-streaming
- ✅ Tool definitions & tool results
- ✅ Multi-turn conversations (3 turns)
- ✅ Large system prompts (skill injection simulation)
- ✅ Minimal responses (edge case)
- ✅ Stop sequences
- ✅ Concurrent requests (3 simultaneous)
- ✅ AgentScope/QwenPaw integration

All 10 test scenarios pass without regression.