### PR TITLE
fix: detect Claude Code Skill tool in read_skills extraction

### DIFF
--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -113,6 +113,7 @@ _VALID_TURN_TYPES = {"main", "side"}
 _TRUE_STRINGS = {"1", "true", "yes", "on"}
 _READ_TOOL_NAMES = {"read", "file_read", "read_file", "readfile"}
 _HERMES_SKILL_READ_TOOL_NAMES = {"skill_view"}
+_CLAUDE_CODE_SKILL_TOOL_NAMES = {"skill"}
 _SKILL_WRITE_TOOL_NAMES = {
     "write",
     "file_write",
@@ -876,6 +877,14 @@ def _extract_read_skills_from_tool_calls(
         tool_name, skill_paths = _extract_skill_paths_from_tool_call(tc)
         normalized = tool_name.lower()
         if normalized in _HERMES_SKILL_READ_TOOL_NAMES:
+            _, skill_name, rel_path = _extract_hermes_skill_name_from_tool_call(tc)
+            skill_ref = _resolve_skill_reference_by_name(skill_name, skill_path_map, rel_path)
+            dedupe_key = skill_ref.get("skill_id") or skill_ref.get("skill_name")
+            if dedupe_key and dedupe_key not in seen_ids:
+                read_skills.append(skill_ref)
+                seen_ids.add(dedupe_key)
+            continue
+        if normalized in _CLAUDE_CODE_SKILL_TOOL_NAMES:
             _, skill_name, rel_path = _extract_hermes_skill_name_from_tool_call(tc)
             skill_ref = _resolve_skill_reference_by_name(skill_name, skill_path_map, rel_path)
             dedupe_key = skill_ref.get("skill_id") or skill_ref.get("skill_name")

--- a/tests/test_skill_bundle_support.py
+++ b/tests/test_skill_bundle_support.py
@@ -375,3 +375,37 @@ def test_hermes_skill_tool_attribution_uses_bundle_child_paths(tmp_path: Path) -
         "path": script_path,
         "action": "skill_manage",
     }]
+
+
+def test_claude_code_skill_tool_detected(tmp_path: Path) -> None:
+    import json
+
+    from skillclaw.api_server import _extract_read_skills_from_tool_calls
+    from skillclaw.skill_manager import SkillManager
+
+    skills_dir = tmp_path / "skills"
+    _write_bytes(skills_dir / "evolve-demo" / "SKILL.md", _skill_md("evolve-demo").encode("utf-8"))
+
+    manager = SkillManager(str(skills_dir))
+    skill_path_map = manager.get_skill_path_map()
+    skill_id = manager.get_all_skills()[0]["id"]
+    evolve_paths = [
+        p for p, info in skill_path_map.items() if info.get("skill_name") == "evolve-demo"
+    ]
+
+    skill_calls = [
+        {
+            "function": {
+                "name": "Skill",
+                "arguments": json.dumps({"skill": "evolve-demo", "args": "some args"}),
+            }
+        }
+    ]
+
+    read_skills = _extract_read_skills_from_tool_calls(skill_calls, skill_path_map)
+
+    assert read_skills == [{
+        "skill_id": skill_id,
+        "skill_name": "evolve-demo",
+        "path": evolve_paths[0],
+    }]


### PR DESCRIPTION
_extract_read_skills_from_tool_calls only recognized Read and skill_view tools, missing Claude Code's Skill tool (e.g. Skill(skill="evolve-demo")). Sessions using skills via Claude Code were incorrectly classified as "no-skill sessions", preventing the evolve pipeline from processing them.
