### PR TITLE
添加OpenCode CLI代理集成支持

### DIFF
--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -113,6 +113,7 @@ _VALID_TURN_TYPES = {"main", "side"}
 _TRUE_STRINGS = {"1", "true", "yes", "on"}
 _READ_TOOL_NAMES = {"read", "file_read", "read_file", "readfile"}
 _HERMES_SKILL_READ_TOOL_NAMES = {"skill_view"}
+_CLAUDE_CODE_SKILL_TOOL_NAMES = {"skill"}
 _SKILL_WRITE_TOOL_NAMES = {
     "write",
     "file_write",
@@ -876,6 +877,14 @@ def _extract_read_skills_from_tool_calls(
         tool_name, skill_paths = _extract_skill_paths_from_tool_call(tc)
         normalized = tool_name.lower()
         if normalized in _HERMES_SKILL_READ_TOOL_NAMES:
+            _, skill_name, rel_path = _extract_hermes_skill_name_from_tool_call(tc)
+            skill_ref = _resolve_skill_reference_by_name(skill_name, skill_path_map, rel_path)
+            dedupe_key = skill_ref.get("skill_id") or skill_ref.get("skill_name")
+            if dedupe_key and dedupe_key not in seen_ids:
+                read_skills.append(skill_ref)
+                seen_ids.add(dedupe_key)
+            continue
+        if normalized in _CLAUDE_CODE_SKILL_TOOL_NAMES:
             _, skill_name, rel_path = _extract_hermes_skill_name_from_tool_call(tc)
             skill_ref = _resolve_skill_reference_by_name(skill_name, skill_path_map, rel_path)
             dedupe_key = skill_ref.get("skill_id") or skill_ref.get("skill_name")

--- a/skillclaw/claw_adapter.py
+++ b/skillclaw/claw_adapter.py
@@ -4,6 +4,7 @@ Claw adapter: auto-configures the active CLI agent to use the SkillClaw proxy.
 
 Supported agents:
   openclaw  — runs `openclaw config set …` + `openclaw gateway restart`
+  opencode  — patches ~/.config/opencode/opencode.json to register SkillClaw provider
   hermes    — patches ~/.hermes/config.yaml to point model traffic at SkillClaw
   codex     — patches ~/.codex/config.toml to register SkillClaw as a provider
   claude    — patches ~/.claude/settings.json to route Anthropic traffic via SkillClaw
@@ -50,6 +51,10 @@ _CLAUDE_HOME = Path.home() / ".claude"
 _CLAUDE_SETTINGS_PATH = _CLAUDE_HOME / "settings.json"
 _CLAUDE_SKILLS_DIR = _CLAUDE_HOME / "skills"
 _CLAUDE_BACKUP_DIR = Path.home() / ".skillclaw" / "backups" / "claude"
+_OPENCODE_CONFIG_DIR = Path.home() / ".config" / "opencode"
+_OPENCODE_CONFIG_PATH = _OPENCODE_CONFIG_DIR / "opencode.json"
+_OPENCODE_SKILLS_DIR = _OPENCODE_CONFIG_DIR / "skills"
+_OPENCODE_BACKUP_DIR = Path.home() / ".skillclaw" / "backups" / "opencode"
 
 
 # ------------------------------------------------------------------ #
@@ -872,6 +877,170 @@ def restore_claude_config(backup_path: Path | None = None) -> dict[str, str]:
 
 
 # ------------------------------------------------------------------ #
+# OpenCode adapter                                                    #
+# ------------------------------------------------------------------ #
+
+
+def _backup_opencode_config_if_changed(config_path: Path, new_text: str) -> Path | None:
+    return _backup_text_file_if_changed(
+        config_path,
+        new_text,
+        backup_dir=_OPENCODE_BACKUP_DIR,
+        backup_stem="opencode",
+        backup_suffix="json",
+        label="OpenCode config",
+    )
+
+
+def _latest_opencode_backup_path() -> Path | None:
+    return _latest_backup_path(_OPENCODE_BACKUP_DIR, "opencode", "json")
+
+
+def _prepare_opencode_skills_dir(cfg: "SkillClawConfig") -> None:
+    target_dir = Path(
+        str(getattr(cfg, "skills_dir", "") or _OPENCODE_SKILLS_DIR)
+    ).expanduser()
+    _prepare_external_skills_dir(target_dir, "OpenCode")
+
+
+def _configure_opencode(cfg: "SkillClawConfig") -> None:
+    """Auto-configure OpenCode to use the SkillClaw proxy."""
+    config_path = _OPENCODE_CONFIG_PATH
+    model_id = cfg.served_model_name or cfg.llm_model_id or "skillclaw-model"
+    api_key = cfg.proxy_api_key or "skillclaw"
+    base_url = f"http://127.0.0.1:{cfg.proxy_port}/v1"
+    _prepare_opencode_skills_dir(cfg)
+
+    data = _load_json_mapping(config_path, "OpenCode")
+
+    provider_block = data.get("provider")
+    if not isinstance(provider_block, dict):
+        provider_block = {}
+        data["provider"] = provider_block
+
+    provider_block["skillclaw"] = {
+        "api": "openai-completions",
+        "name": "SkillClaw",
+        "options": {
+            "apiKey": api_key,
+            "baseURL": base_url,
+        },
+        "models": {
+            model_id: {
+                "id": model_id,
+                "name": model_id,
+                "reasoning": False,
+                "input": ["text"],
+                "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+                "contextWindow": 32768,
+                "maxTokens": 8192,
+            }
+        },
+    }
+
+    data["model"] = f"skillclaw/{model_id}"
+
+    new_text = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    _backup_opencode_config_if_changed(config_path, new_text)
+    _write_json_mapping_atomic(config_path, data, "OpenCode")
+
+
+def inspect_opencode_config(cfg: "SkillClawConfig") -> dict[str, object]:
+    """Return a diagnostic snapshot of the local OpenCode integration state."""
+    config_path = _OPENCODE_CONFIG_PATH
+    expected_model = cfg.served_model_name or cfg.llm_model_id or "skillclaw-model"
+    expected_base_url = f"http://127.0.0.1:{cfg.proxy_port}/v1"
+    expected_api_key = cfg.proxy_api_key or "skillclaw"
+    expected_skills_dir = Path(
+        str(getattr(cfg, "skills_dir", "") or _OPENCODE_SKILLS_DIR)
+    ).expanduser()
+
+    data = _load_json_mapping(config_path, "OpenCode")
+    provider_block = data.get("provider") if isinstance(data, dict) else {}
+    if not isinstance(provider_block, dict):
+        provider_block = {}
+
+    skillclaw_block = provider_block.get("skillclaw")
+    if not isinstance(skillclaw_block, dict):
+        skillclaw_block = {}
+    skillclaw_options = skillclaw_block.get("options")
+    if not isinstance(skillclaw_options, dict):
+        skillclaw_options = {}
+
+    configured_base_url = str(skillclaw_options.get("baseURL", "") or "")
+    configured_api_key = str(skillclaw_options.get("apiKey", "") or "")
+    configured_model = str(data.get("model", "") or "")
+    configured_api = str(skillclaw_block.get("api", "") or "")
+
+    proxy_match = (
+        configured_api == "openai-completions"
+        and configured_base_url == expected_base_url
+        and configured_model == f"skillclaw/{expected_model}"
+    )
+
+    backup_path = _latest_opencode_backup_path()
+    uses_default_skills_dir = expected_skills_dir == _OPENCODE_SKILLS_DIR
+    issues: list[str] = []
+    notes: list[str] = [
+        "OpenCode uses SkillClaw through a custom provider block in"
+        " ~/.config/opencode/opencode.json.",
+        "OpenCode session capture falls back to proxy-side heuristics"
+        " because OpenCode does not send explicit SkillClaw session headers.",
+    ]
+    next_steps: list[str] = []
+
+    if not config_path.exists():
+        issues.append("OpenCode config is missing: ~/.config/opencode/opencode.json")
+    if not proxy_match:
+        issues.append("OpenCode model routing is not pointing at the local SkillClaw proxy.")
+        next_steps.append(
+            "Start SkillClaw once with `claw_type=opencode` so it can rewrite ~/.config/opencode/opencode.json."
+        )
+    if not expected_skills_dir.is_dir():
+        issues.append(f"OpenCode skills directory is missing: {expected_skills_dir}")
+        next_steps.append(f"Create or prepare the OpenCode skills directory: {expected_skills_dir}")
+
+    if not backup_path:
+        next_steps.append(
+            "Run SkillClaw once before relying on `skillclaw restore opencode`, so a backup can be created."
+        )
+
+    return {
+        "status": "ok" if not issues else "warning",
+        "config_path": str(config_path),
+        "config_exists": config_path.exists(),
+        "integration_scope": "opencode-only",
+        "expected_model": expected_model,
+        "expected_base_url": expected_base_url,
+        "configured_api": configured_api or "(unset)",
+        "configured_base_url": configured_base_url or "(unset)",
+        "configured_model": configured_model or "(unset)",
+        "configured_api_key": "(obscured)" if configured_api_key else "(unset)",
+        "proxy_match": proxy_match,
+        "expected_skills_dir": str(expected_skills_dir),
+        "skills_dir_exists": expected_skills_dir.is_dir(),
+        "skills_dir_mode": "opencode-default" if uses_default_skills_dir else "custom",
+        "latest_backup": str(backup_path) if backup_path else "(none)",
+        "session_boundary_mode": "proxy heuristics",
+        "issues": issues,
+        "notes": notes,
+        "next_steps": next_steps,
+    }
+
+
+def restore_opencode_config(backup_path: Path | None = None) -> dict[str, str]:
+    """Restore ~/.config/opencode/opencode.json from the latest or a specified backup."""
+    source = Path(backup_path).expanduser() if backup_path is not None else _latest_opencode_backup_path()
+    if source is None or not source.exists():
+        raise FileNotFoundError("No OpenCode backup found")
+
+    text = source.read_text(encoding="utf-8")
+    target = _OPENCODE_CONFIG_PATH
+    _write_text_atomic(target, text, "OpenCode config restore")
+    return {"source": str(source), "target": str(target)}
+
+
+# ------------------------------------------------------------------ #
 # QwenPaw adapter                                                     #
 # ------------------------------------------------------------------ #
 
@@ -1426,6 +1595,7 @@ _ADAPTERS: dict[str, Callable[["SkillClawConfig"], None]] = {
     "hermes": _configure_hermes,
     "codex": _configure_codex,
     "claude": _configure_claude,
+    "opencode": _configure_opencode,
     "qwenpaw": _configure_qwenpaw,
     "ironclaw": _configure_ironclaw,
     "picoclaw": _configure_picoclaw,

--- a/skillclaw/cli.py
+++ b/skillclaw/cli.py
@@ -446,6 +446,19 @@ def doctor_claude():
     _echo_report(report)
 
 
+@doctor.command(name="opencode")
+def doctor_opencode():
+    """Inspect the local OpenCode integration state."""
+    from .claw_adapter import inspect_opencode_config
+
+    cs = ConfigStore()
+    if not cs.exists():
+        raise click.ClickException("No config file found. Run 'skillclaw setup' first.")
+
+    report = inspect_opencode_config(cs.to_skillclaw_config())
+    _echo_report(report)
+
+
 @skillclaw.group()
 def restore():
     """Restore agent integration state from backups."""
@@ -509,6 +522,26 @@ def restore_claude(backup_path: str | None):
         raise click.ClickException(str(exc)) from None
 
     click.echo(f"Restored Claude Code settings: {result['target']} <- {result['source']}")
+
+
+@restore.command(name="opencode")
+@click.option(
+    "--backup",
+    "backup_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    default=None,
+    help="Restore from a specific backup file instead of the latest OpenCode backup.",
+)
+def restore_opencode(backup_path: str | None):
+    """Restore ~/.config/opencode/opencode.json from a saved backup."""
+    from .claw_adapter import restore_opencode_config
+
+    try:
+        result = restore_opencode_config(Path(backup_path).expanduser() if backup_path else None)
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from None
+
+    click.echo(f"Restored OpenCode config: {result['target']} <- {result['source']}")
 
 
 @skillclaw.group()

--- a/skillclaw/config_store.py
+++ b/skillclaw/config_store.py
@@ -18,6 +18,7 @@ _DEFAULT_SKILLS_DIR = CONFIG_DIR / "skills"
 _DEFAULT_HERMES_SKILLS_DIR = Path.home() / ".hermes" / "skills"
 _DEFAULT_CODEX_SKILLS_DIR = Path.home() / ".codex" / "skills"
 _DEFAULT_CLAUDE_SKILLS_DIR = Path.home() / ".claude" / "skills"
+_DEFAULT_OPENCODE_SKILLS_DIR = Path.home() / ".config" / "opencode" / "skills"
 
 _DEFAULTS: dict = {
     "llm": {
@@ -155,6 +156,8 @@ def default_skills_dir_for_claw(claw_type: str) -> Path:
         return _DEFAULT_CODEX_SKILLS_DIR
     if normalized == "claude":
         return _DEFAULT_CLAUDE_SKILLS_DIR
+    if normalized == "opencode":
+        return _DEFAULT_OPENCODE_SKILLS_DIR
     return _DEFAULT_SKILLS_DIR
 
 
@@ -171,7 +174,7 @@ def resolve_skills_dir(skills_dir: Any, *, claw_type: str) -> str:
 
     if raw:
         expanded = Path(raw).expanduser()
-        if normalized_claw in {"hermes", "codex", "claude"} and expanded == generic_default:
+        if normalized_claw in {"hermes", "codex", "claude", "opencode"} and expanded == generic_default:
             return str(default_skills_dir_for_claw(normalized_claw))
         return str(expanded)
 

--- a/skillclaw/runtime_state.py
+++ b/skillclaw/runtime_state.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -20,9 +21,7 @@ def daemon_start_lock_path() -> Path:
     return _state_dir() / "daemon_start.lock"
 
 
-def process_alive(pid: int) -> bool:
-    if pid <= 0:
-        return False
+def _process_alive_unix(pid: int) -> bool:
     try:
         os.kill(pid, 0)
         return True
@@ -32,6 +31,28 @@ def process_alive(pid: int) -> bool:
         return False
     except OSError:
         return False
+
+
+def _process_alive_windows(pid: int) -> bool:
+    import ctypes
+    kernel32 = ctypes.windll.kernel32
+    PROCESS_QUERY_INFORMATION = 0x0400
+    handle = kernel32.OpenProcess(PROCESS_QUERY_INFORMATION, False, pid)
+    if handle:
+        kernel32.CloseHandle(handle)
+        return True
+    return False
+
+
+_USE_WINDOWS = platform.system() == "Windows"
+
+
+def process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    if _USE_WINDOWS:
+        return _process_alive_windows(pid)
+    return _process_alive_unix(pid)
 
 
 def _coerce_pid(value: Any) -> int | None:

--- a/tests/test_skill_bundle_support.py
+++ b/tests/test_skill_bundle_support.py
@@ -375,3 +375,37 @@ def test_hermes_skill_tool_attribution_uses_bundle_child_paths(tmp_path: Path) -
         "path": script_path,
         "action": "skill_manage",
     }]
+
+
+def test_claude_code_skill_tool_detected(tmp_path: Path) -> None:
+    import json
+
+    from skillclaw.api_server import _extract_read_skills_from_tool_calls
+    from skillclaw.skill_manager import SkillManager
+
+    skills_dir = tmp_path / "skills"
+    _write_bytes(skills_dir / "evolve-demo" / "SKILL.md", _skill_md("evolve-demo").encode("utf-8"))
+
+    manager = SkillManager(str(skills_dir))
+    skill_path_map = manager.get_skill_path_map()
+    skill_id = manager.get_all_skills()[0]["id"]
+    evolve_paths = [
+        p for p, info in skill_path_map.items() if info.get("skill_name") == "evolve-demo"
+    ]
+
+    skill_calls = [
+        {
+            "function": {
+                "name": "Skill",
+                "arguments": json.dumps({"skill": "evolve-demo", "args": "some args"}),
+            }
+        }
+    ]
+
+    read_skills = _extract_read_skills_from_tool_calls(skill_calls, skill_path_map)
+
+    assert read_skills == [{
+        "skill_id": skill_id,
+        "skill_name": "evolve-demo",
+        "path": evolve_paths[0],
+    }]


### PR DESCRIPTION
1. Add OpenCode adapter to auto-configure ~/.config/opencode/opencode.json with SkillClaw provider

2. Add skillclaw doctor opencode and skillclaw restore opencode CLI commands

3. Register default OpenCode skills directory in config_store

4. Fix process_alive() for Windows via ctypes.windll.kernel32.OpenProcess