### PR TITLE
Add Nacos-backed skill sync

### DIFF
--- a/evolve_server/core/config.py
+++ b/evolve_server/core/config.py
@@ -104,6 +104,16 @@ class EvolveServerConfig:
     validation_max_rejections: int = 1
     debug_dump_dir: str = ""
 
+    # Skill registry. Session queues and validation artifacts still use the
+    # storage settings above; this controls only skill assets/lifecycle.
+    skill_storage_backend: str = ""
+    nacos_server: str = ""
+    nacos_namespace_id: str = "public"
+    nacos_access_token: str = ""
+    nacos_username: str = ""
+    nacos_password: str = ""
+    nacos_label: str = "latest"
+
     # Scheduling
     interval_seconds: int = 600
     http_port: int = 8787
@@ -222,6 +232,13 @@ class EvolveServerConfig:
             validation_required_approvals=int(os.environ.get("EVOLVE_VALIDATION_REQUIRED_APPROVALS", "1")),
             validation_min_mean_score=float(os.environ.get("EVOLVE_VALIDATION_MIN_MEAN_SCORE", "0.75")),
             validation_max_rejections=int(os.environ.get("EVOLVE_VALIDATION_MAX_REJECTIONS", "1")),
+            skill_storage_backend=os.environ.get("EVOLVE_SKILL_STORAGE_BACKEND", ""),
+            nacos_server=os.environ.get("EVOLVE_NACOS_SERVER", ""),
+            nacos_namespace_id=os.environ.get("EVOLVE_NACOS_NAMESPACE_ID", "public"),
+            nacos_access_token=os.environ.get("EVOLVE_NACOS_ACCESS_TOKEN", ""),
+            nacos_username=os.environ.get("EVOLVE_NACOS_USERNAME", ""),
+            nacos_password=os.environ.get("EVOLVE_NACOS_PASSWORD", ""),
+            nacos_label=os.environ.get("EVOLVE_NACOS_LABEL", "latest"),
             interval_seconds=int(os.environ.get("EVOLVE_INTERVAL", "600")),
             http_port=int(os.environ.get("EVOLVE_PORT", "8787")),
             history_path=os.environ.get("EVOLVE_HISTORY_LOG", "evolve_history.jsonl"),
@@ -238,7 +255,8 @@ class EvolveServerConfig:
     def from_skillclaw_config(cls, config) -> "EvolveServerConfig":
         """Build from an existing ``SkillClawConfig`` (reuse sharing + LLM settings)."""
         engine = _first_env("EVOLVE_ENGINE", default="workflow").strip().lower() or "workflow"
-        storage_backend = str(getattr(config, "sharing_backend", "") or "").strip().lower()
+        sharing_backend = str(getattr(config, "sharing_backend", "") or "").strip().lower()
+        session_backend = str(getattr(config, "sharing_session_backend", "") or "").strip().lower()
         storage_endpoint = str(
             getattr(config, "sharing_endpoint", "") or getattr(config, "sharing_oss_endpoint", "") or ""
         )
@@ -281,8 +299,23 @@ class EvolveServerConfig:
 
         return cls(
             engine=engine,
-            storage_backend=storage_backend
-            or ("local" if local_root else "s3" if (storage_bucket or storage_endpoint) else "oss"),
+            storage_backend=_first_env("EVOLVE_STORAGE_BACKEND", default="")
+            or (
+                session_backend
+                if session_backend
+                else "local"
+                if local_root
+                else "s3"
+                if (storage_bucket or storage_endpoint) and sharing_backend != "nacos"
+                else ""
+            )
+            or (
+                "local"
+                if local_root
+                else "oss"
+                if sharing_backend != "nacos"
+                else ""
+            ),
             storage_endpoint=storage_endpoint,
             storage_bucket=storage_bucket,
             storage_access_key_id=storage_access_key_id,
@@ -311,6 +344,13 @@ class EvolveServerConfig:
             validation_required_approvals=int(os.environ.get("EVOLVE_VALIDATION_REQUIRED_APPROVALS", "1")),
             validation_min_mean_score=float(os.environ.get("EVOLVE_VALIDATION_MIN_MEAN_SCORE", "0.75")),
             validation_max_rejections=int(os.environ.get("EVOLVE_VALIDATION_MAX_REJECTIONS", "1")),
+            skill_storage_backend="nacos" if sharing_backend == "nacos" else "",
+            nacos_server=str(getattr(config, "sharing_nacos_server", "") or storage_endpoint),
+            nacos_namespace_id=str(getattr(config, "sharing_nacos_namespace_id", "") or "public"),
+            nacos_access_token=str(getattr(config, "sharing_nacos_access_token", "") or ""),
+            nacos_username=str(getattr(config, "sharing_nacos_username", "") or ""),
+            nacos_password=str(getattr(config, "sharing_nacos_password", "") or ""),
+            nacos_label=str(getattr(config, "sharing_nacos_label", "") or "latest"),
             openclaw_bin=os.environ.get("AGENT_EVOLVE_OPENCLAW_BIN", "openclaw"),
             openclaw_home=os.environ.get("AGENT_EVOLVE_OPENCLAW_HOME", ""),
             fresh=os.environ.get("AGENT_EVOLVE_FRESH", "1").lower() not in {"0", "false", "no"},

--- a/evolve_server/engines/workflow.py
+++ b/evolve_server/engines/workflow.py
@@ -82,11 +82,39 @@ class EvolveServer(EvolveEngineMixin):
             group_id=self.config.group_id,
         )
         self._id_registry = SkillIDRegistry()
+        self._nacos_skill_client = self._build_nacos_skill_client()
         self._running = False
 
         set_evolve_debug_dir(config.debug_dump_dir)
         set_summarizer_debug_dir(config.debug_dump_dir)
-        self._id_registry.load_from_oss(self._bucket, self._prefix)
+        if not self._uses_nacos_skill_registry():
+            self._id_registry.load_from_oss(self._bucket, self._prefix)
+
+    def _uses_nacos_skill_registry(self) -> bool:
+        return str(getattr(self.config, "skill_storage_backend", "") or "").strip().lower() == "nacos"
+
+    def _build_nacos_skill_client(self) -> Any | None:
+        if not self._uses_nacos_skill_registry():
+            return None
+        from skillclaw.nacos_skill_hub import NacosSkillClient
+
+        return NacosSkillClient(
+            server=str(getattr(self.config, "nacos_server", "") or ""),
+            namespace_id=str(getattr(self.config, "nacos_namespace_id", "") or "public"),
+            access_token=str(getattr(self.config, "nacos_access_token", "") or ""),
+            username=str(getattr(self.config, "nacos_username", "") or ""),
+            password=str(getattr(self.config, "nacos_password", "") or ""),
+        )
+
+    def _load_remote_skills(self) -> dict[str, dict[str, Any]]:
+        if self._nacos_skill_client is not None:
+            skills: dict[str, dict[str, Any]] = {}
+            for item in self._nacos_skill_client.list_skills():
+                name = str(item.get("name") or "")
+                if name:
+                    skills[name] = item
+            return skills
+        return super()._load_remote_skills()
 
     def _load_remote_skill_record(self, name: str) -> Optional[dict[str, Any]]:
         rec = self._load_remote_skills().get(name)
@@ -109,11 +137,56 @@ class EvolveServer(EvolveEngineMixin):
         return skill
 
     def _fetch_skill(self, name: str) -> Optional[str]:
+        if self._nacos_skill_client is not None:
+            try:
+                from skillclaw.nacos_skill_hub import _nacos_zip_to_bundle
+
+                record = self._load_remote_skill_record(name) or {}
+                labels = record.get("labels") if isinstance(record.get("labels"), dict) else {}
+                version = labels.get(str(getattr(self.config, "nacos_label", "") or "latest"))
+                zip_bytes = self._nacos_skill_client.download_skill_zip(
+                    name,
+                    version=version,
+                    label=str(getattr(self.config, "nacos_label", "") or "latest"),
+                )
+                bundle = _nacos_zip_to_bundle(zip_bytes)
+                data = bundle.get("SKILL.md")
+                return data.decode("utf-8") if data is not None else None
+            except Exception as exc:
+                logger.warning("[EvolveServer] failed to fetch Nacos skill %s: %s", name, exc)
+                return None
         return fetch_skill_content(self._bucket, self._prefix, name)
 
     def _upload_skill(self, skill: dict, action: str) -> None:
         name = skill.get("name", "")
         if not name:
+            return
+
+        if self._nacos_skill_client is not None:
+            from skillclaw.nacos_skill_hub import _bundle_to_nacos_zip, _next_version
+
+            md_content = build_skill_md(skill)
+            md_bytes = md_content.encode("utf-8")
+            record = self._load_remote_skill_record(name) or {}
+            try:
+                detail = self._nacos_skill_client.get_skill(name) if record else {}
+            except Exception:
+                detail = {}
+            target_version = _next_version(record, detail)
+            zip_bytes = _bundle_to_nacos_zip(name, {"SKILL.md": md_bytes})
+            self._nacos_skill_client.upload_skill_zip(
+                zip_bytes=zip_bytes,
+                filename=f"{name}-{target_version}.zip",
+                overwrite=True,
+                target_version=target_version,
+            )
+            self._nacos_skill_client.submit(name, target_version)
+            logger.info(
+                "[EvolveServer] uploaded and submitted skill %s to Nacos as %s via action=%s",
+                name,
+                target_version,
+                action,
+            )
             return
 
         skill_id = self._id_registry.get_or_create(name)
@@ -163,6 +236,14 @@ class EvolveServer(EvolveEngineMixin):
         )
 
     def _detect_conflict(self, name: str, incoming_skill: dict) -> bool:
+        if self._nacos_skill_client is not None:
+            existing_md = self._fetch_skill(name)
+            if not existing_md:
+                return False
+            existing_sha = hashlib.sha256(existing_md.encode("utf-8")).hexdigest()
+            incoming_md = build_skill_md(incoming_skill)
+            incoming_sha = hashlib.sha256(incoming_md.encode("utf-8")).hexdigest()
+            return existing_sha != incoming_sha
         existing_sha = self._id_registry.get_content_sha(name)
         if not existing_sha:
             return False
@@ -744,7 +825,8 @@ class EvolveServer(EvolveEngineMixin):
         published_records, validation_publish_summary = await self._finalize_validation_jobs()
         all_records = evolution_records + published_records
 
-        await self._call_storage(self._id_registry.save_to_oss, self._bucket, self._prefix)
+        if not self._uses_nacos_skill_registry():
+            await self._call_storage(self._id_registry.save_to_oss, self._bucket, self._prefix)
         if session_keys and not had_processing_error:
             await self._call_storage(delete_session_keys, self._bucket, session_keys)
         elif session_keys and had_processing_error:
@@ -813,7 +895,11 @@ class EvolveServer(EvolveEngineMixin):
 
         @app.get("/status")
         async def status():
-            entries = self._id_registry.all_entries()
+            entries = (
+                self._load_remote_skills()
+                if self._uses_nacos_skill_registry()
+                else self._id_registry.all_entries()
+            )
             pending_keys = await self._call_storage(list_session_keys, self._bucket, self._prefix)
             return JSONResponse(
                 content={
@@ -822,8 +908,8 @@ class EvolveServer(EvolveEngineMixin):
                     "registered_skills": len(entries),
                     "skills": {
                         name: {
-                            "skill_id": item["skill_id"],
-                            "version": item.get("version", 0),
+                            "skill_id": item.get("skill_id") or item.get("name") or name,
+                            "version": item.get("version") or (item.get("labels") or {}).get("latest") or 0,
                         }
                         for name, item in entries.items()
                     },

--- a/scripts/demo_nacos_skill_lifecycle.py
+++ b/scripts/demo_nacos_skill_lifecycle.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""Demo SkillClaw's Nacos-backed skill lifecycle without a real Nacos server.
+
+The demo uses httpx.MockTransport to show the exact lifecycle SkillClaw now
+drives against Nacos:
+
+1. Upload local skill zip as a target version.
+2. Submit the version for review.
+3. In this mock, Nacos audit is disabled, so submit auto-publishes latest.
+4. Pull latest back into a local skills directory.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+import sys
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from skillclaw.nacos_skill_hub import NacosSkillClient, NacosSkillHub, _bundle_to_nacos_zip
+
+
+SKILL_MD = """---
+name: demo-skill
+description: Demo Nacos lifecycle skill
+---
+
+# Demo Skill
+
+Use this skill to demonstrate Nacos-backed lifecycle management.
+"""
+
+
+def _json(data):
+    return httpx.Response(200, json={"code": 0, "data": data})
+
+
+def main() -> None:
+    calls: list[str] = []
+    published_zip = _bundle_to_nacos_zip(
+        "demo-skill",
+        {
+            "SKILL.md": SKILL_MD.encode("utf-8"),
+            "references/demo.md": b"demo reference\n",
+        },
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/v3/admin/ai/skills/list":
+            return _json({"totalCount": 0, "pageItems": []})
+        if request.url.path == "/v3/admin/ai/skills/upload":
+            return _json("demo-skill")
+        if request.url.path == "/v3/admin/ai/skills/submit":
+            return _json("v1")
+        if request.url.path == "/v3/client/ai/skills":
+            return httpx.Response(200, content=published_zip)
+        raise RuntimeError(f"unexpected request: {request.method} {request.url}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        skills_dir = root / "skills"
+        skill_dir = skills_dir / "demo-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+        (skill_dir / "references").mkdir()
+        (skill_dir / "references" / "demo.md").write_text("demo reference\n", encoding="utf-8")
+
+        client = NacosSkillClient(
+            server="http://nacos-demo.local",
+            namespace_id="public",
+            transport=httpx.MockTransport(handler),
+        )
+        hub = NacosSkillHub(client=client)
+
+        push = hub.push_skills(str(skills_dir))
+        pulled_dir = root / "pulled"
+
+        def list_after_publish(request: httpx.Request) -> httpx.Response:
+            calls.append(f"{request.method} {request.url.path}")
+            if request.url.path == "/v3/admin/ai/skills/list":
+                return _json(
+                    {
+                        "totalCount": 1,
+                        "pageItems": [{"name": "demo-skill", "labels": {"latest": "v1"}}],
+                    }
+                )
+            if request.url.path == "/v3/client/ai/skills":
+                return httpx.Response(200, content=published_zip)
+            raise RuntimeError(f"unexpected request: {request.method} {request.url}")
+
+        client._client = httpx.Client(transport=httpx.MockTransport(list_after_publish))
+        pull = hub.pull_skills(str(pulled_dir))
+
+        print("SkillClaw Nacos lifecycle demo")
+        print("mock mode: Nacos audit disabled, submit auto-publishes latest")
+        print(f"push: uploaded={push['uploaded']} submitted={push['submitted']}")
+        print(f"pull: downloaded={pull['downloaded']} total_remote={pull['total_remote']}")
+        print(f"pulled skill: {pulled_dir / 'demo-skill' / 'SKILL.md'}")
+        print("nacos calls:")
+        for call in calls:
+            print(f"  {call}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -2757,7 +2757,13 @@ class SkillClawAPIServer:
         try:
             from .skill_hub import SkillHub
 
-            hub = SkillHub.from_config(self.config)
+            hub = SkillHub.object_storage_from_config(self.config)
+            if hub is None:
+                logger.info(
+                    "[SkillHub] session remote upload skipped: no local/OSS/S3 storage configured "
+                    "(skill registry may still use Nacos)"
+                )
+                return
             session_payload = {
                 "session_id": session_id,
                 "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
@@ -2794,11 +2800,15 @@ class SkillClawAPIServer:
             hub = SkillHub.from_config(self.config)
             pull_result = hub.pull_skills(self.config.skills_dir, skip_names=skip_names)
             logger.info(
-                "[SkillHub] skill pull: %d downloaded, %d unchanged, %d deleted",
+                "[SkillHub] skill pull: %d downloaded, %d unchanged, %d failed, %d deleted, %d total remote",
                 pull_result["downloaded"],
                 pull_result["skipped"],
+                pull_result.get("failed", 0),
                 pull_result.get("deleted", 0),
+                pull_result.get("total_remote", 0),
             )
+            if pull_result.get("failed_names"):
+                logger.warning("[SkillHub] skill pull failed names: %s", ", ".join(pull_result["failed_names"]))
             if self.skill_manager and (
                 pull_result.get("downloaded", 0) > 0
                 or pull_result.get("deleted", 0) > 0

--- a/skillclaw/cli.py
+++ b/skillclaw/cli.py
@@ -761,6 +761,11 @@ def _sharing_target(cfg) -> str:
     group = getattr(cfg, "sharing_group_id", "default")
     if backend == "local":
         return f"local storage ({cfg.sharing_local_root}/{group})"
+    if backend == "nacos":
+        server = getattr(cfg, "sharing_nacos_server", "") or getattr(cfg, "sharing_endpoint", "")
+        namespace_id = getattr(cfg, "sharing_nacos_namespace_id", "public")
+        label = getattr(cfg, "sharing_nacos_label", "latest")
+        return f"nacos ({namespace_id}, label={label} @ {server})"
     bucket = getattr(cfg, "sharing_bucket", "")
     endpoint = getattr(cfg, "sharing_endpoint", "")
     target = f"{bucket}/{group}" if bucket else group
@@ -797,8 +802,15 @@ def _require_sharing(cs: ConfigStore):
             raise click.ClickException(
                 "OSS credentials are not configured. Set sharing.access_key_id and sharing.secret_access_key."
             )
+    elif backend == "nacos":
+        if not (getattr(cfg, "sharing_nacos_server", "") or getattr(cfg, "sharing_endpoint", "")):
+            raise click.ClickException(
+                "Nacos sharing backend is not configured. Set sharing.nacos_server or sharing.endpoint first."
+            )
     else:
-        raise click.ClickException("Sharing backend is not configured. Set sharing.backend to local, s3, or oss.")
+        raise click.ClickException(
+            "Sharing backend is not configured. Set sharing.backend to local, s3, oss, or nacos."
+        )
     from .skill_hub import SkillHub
 
     hub = SkillHub.from_config(cfg)
@@ -833,7 +845,29 @@ def skills_push(no_filter):
         f"Done: {result['uploaded']} uploaded, "
         f"{result['skipped']} unchanged, "
         f"{result.get('filtered', 0)} filtered, "
+        f"{result.get('submitted', 0)} submitted, "
         f"{result['total_local']} total local skills."
+    )
+
+
+@skills.command(name="publish")
+@click.argument("name")
+@click.argument("version")
+@click.option(
+    "--no-update-latest",
+    is_flag=True,
+    help="Publish the version without updating the latest label.",
+)
+def skills_publish(name, version, no_update_latest):
+    """Publish an approved Nacos skill version."""
+    cs = ConfigStore()
+    cfg, hub = _require_sharing(cs)
+    if _sharing_backend(cfg) != "nacos" or not hasattr(hub, "publish_skill"):
+        raise click.ClickException("skills publish is only available when sharing.backend is nacos.")
+    result = hub.publish_skill(name, version, update_latest_label=not no_update_latest)
+    click.echo(
+        f"Published {result['skill_name']} {result['version']} "
+        f"(updated latest: {result['updated_latest_label']})."
     )
 
 
@@ -847,9 +881,12 @@ def skills_pull():
     msg = (
         f"Done: {result['downloaded']} downloaded, "
         f"{result['skipped']} unchanged, "
+        f"{result.get('failed', 0)} failed, "
         f"{result.get('deleted', 0)} deleted, "
         f"{result['total_remote']} total remote skills."
     )
+    if result.get("failed_names"):
+        msg += f" Failed: {', '.join(result.get('failed_names', []))}"
     if result.get("restored_from_backup"):
         msg += f" Restored from backup: {result.get('backup_dir', '')}"
     click.echo(msg)

--- a/skillclaw/config.py
+++ b/skillclaw/config.py
@@ -87,6 +87,15 @@ class SkillClawConfig:
     sharing_region: str = ""
     sharing_session_token: str = ""
     sharing_local_root: str = ""
+    # Optional object-storage backend for non-skill artifacts when
+    # sharing_backend is reserved for the Skill registry.
+    sharing_session_backend: str = ""
+    sharing_nacos_server: str = ""
+    sharing_nacos_namespace_id: str = "public"
+    sharing_nacos_access_token: str = ""
+    sharing_nacos_username: str = ""
+    sharing_nacos_password: str = ""
+    sharing_nacos_label: str = "latest"
 
     sharing_group_id: str = "default"
     sharing_user_alias: str = ""

--- a/skillclaw/config_store.py
+++ b/skillclaw/config_store.py
@@ -69,6 +69,13 @@ _DEFAULTS: dict = {
         "region": "",
         "session_token": "",
         "local_root": "",
+        "session_backend": "",
+        "nacos_server": "",
+        "nacos_namespace_id": "public",
+        "nacos_access_token": "",
+        "nacos_username": "",
+        "nacos_password": "",
+        "nacos_label": "latest",
         "group_id": "default",
         "user_alias": "",
         "auto_pull_on_start": False,
@@ -286,6 +293,7 @@ class ConfigStore:
         sharing_region = _first_non_empty(sharing, "region")
         sharing_session_token = _first_non_empty(sharing, "session_token")
         sharing_local_root = _first_non_empty(sharing, "local_root")
+        sharing_session_backend = _first_non_empty(sharing, "session_backend")
 
         prm_provider = prm.get("provider", "openai")
         prm_url = str(prm.get("url", "") or llm_api_base)
@@ -346,6 +354,21 @@ class ConfigStore:
             sharing_region=sharing_region,
             sharing_session_token=sharing_session_token,
             sharing_local_root=sharing_local_root,
+            sharing_session_backend=sharing_session_backend,
+            sharing_nacos_server=str(sharing.get("nacos_server", "") or sharing_endpoint),
+            sharing_nacos_namespace_id=str(
+                sharing.get("nacos_namespace_id", "")
+                or sharing.get("namespace_id", "")
+                or "public"
+            ),
+            sharing_nacos_access_token=str(
+                sharing.get("nacos_access_token", "")
+                or sharing.get("access_token", "")
+                or ""
+            ),
+            sharing_nacos_username=str(sharing.get("nacos_username", "") or sharing.get("username", "") or ""),
+            sharing_nacos_password=str(sharing.get("nacos_password", "") or sharing.get("password", "") or ""),
+            sharing_nacos_label=str(sharing.get("nacos_label", "") or sharing.get("label", "") or "latest"),
             sharing_group_id=str(sharing.get("group_id", "default") or "default"),
             sharing_user_alias=str(sharing.get("user_alias", "") or ""),
             sharing_auto_pull_on_start=bool(sharing.get("auto_pull_on_start", False)),
@@ -415,6 +438,16 @@ class ConfigStore:
             if backend == "local":
                 lines += [
                     f"sharing.local_root: {sharing.get('local_root', '?')}",
+                ]
+            elif backend == "nacos":
+                lines += [
+                    f"sharing.nacos_server: {sharing.get('nacos_server') or sharing.get('endpoint', '?')}",
+                    "sharing.nacos_namespace: "
+                    f"{sharing.get('nacos_namespace_id') or sharing.get('namespace_id', 'public')}",
+                    f"sharing.nacos_label: {sharing.get('nacos_label') or sharing.get('label', 'latest')}",
+                    "sharing.nacos_lifecycle: upload -> submit; review/publish policy is controlled by Nacos",
+                    "sharing.session_backend: "
+                    f"{sharing.get('session_backend') or ('local' if sharing.get('local_root') else 'not configured')}",
                 ]
             else:
                 lines += [

--- a/skillclaw/nacos_skill_hub.py
+++ b/skillclaw/nacos_skill_hub.py
@@ -1,0 +1,474 @@
+"""Nacos-backed skill sharing for SkillClaw.
+
+This adapter intentionally uses Nacos' skill lifecycle API instead of mapping
+Nacos onto the generic object-store protocol. Local skills remain normal
+directories; Nacos owns remote versions, review submission, publish, labels,
+and online state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import os
+import shutil
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Collection, Optional
+
+import httpx
+
+from .skill_bundle import (
+    bundle_entrypoint_text,
+    bundle_file_records,
+    bundle_tree_sha256,
+    read_skill_bundle_with_meta,
+    write_skill_bundle,
+)
+from .skill_hub import _is_hermes_skill_root, _skill_dir_for_root
+
+logger = logging.getLogger(__name__)
+
+
+class NacosSkillClient:
+    """Small synchronous client for Nacos Skill admin/client endpoints."""
+
+    def __init__(
+        self,
+        *,
+        server: str,
+        namespace_id: str = "public",
+        access_token: str = "",
+        username: str = "",
+        password: str = "",
+        timeout: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.server = str(server or "").rstrip("/")
+        if not self.server:
+            raise ValueError("Nacos sharing requires sharing.nacos_server or sharing.endpoint.")
+        self.namespace_id = str(namespace_id or "public")
+        self.access_token = access_token
+        self.username = username
+        self.password = password
+        self._client = httpx.Client(timeout=timeout, transport=transport)
+        if not self.access_token and self.username and self.password:
+            self._login()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def _login(self) -> None:
+        response = self._client.post(
+            f"{self.server}/v1/auth/login",
+            data={"username": self.username, "password": self.password},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        token = payload.get("accessToken") or payload.get("data", {}).get("accessToken", "")
+        if not token:
+            raise RuntimeError(f"Nacos login failed: no accessToken in response: {payload}")
+        self.access_token = token
+        logger.info("[NacosSkillClient] logged in as %s", self.username)
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self.access_token:
+            headers["accessToken"] = self.access_token
+        return headers
+
+    def _url(self, path: str) -> str:
+        return f"{self.server}{path}"
+
+    @staticmethod
+    def _unwrap_json(response: httpx.Response) -> Any:
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            return payload
+        if "data" in payload:
+            code = payload.get("code")
+            if code not in (None, 0, 200, "0", "200"):
+                raise RuntimeError(payload.get("message") or payload.get("msg") or f"Nacos request failed: {payload}")
+            return payload.get("data")
+        return payload
+
+    def list_skills(self, *, page_size: int = 100) -> list[dict[str, Any]]:
+        page_no = 1
+        out: list[dict[str, Any]] = []
+        while True:
+            data = self._unwrap_json(
+                self._client.get(
+                    self._url("/v3/admin/ai/skills/list"),
+                    params={
+                        "namespaceId": self.namespace_id,
+                        "pageNo": page_no,
+                        "pageSize": page_size,
+                    },
+                    headers=self._headers(),
+                )
+            )
+            if isinstance(data, list):
+                out.extend(item for item in data if isinstance(item, dict))
+                return out
+            if not isinstance(data, dict):
+                return out
+            items = data.get("pageItems") or data.get("items") or []
+            out.extend(item for item in items if isinstance(item, dict))
+            total = int(data.get("totalCount") or len(out) or 0)
+            if len(out) >= total or not items:
+                return out
+            page_no += 1
+
+    def get_skill(self, name: str) -> dict[str, Any]:
+        data = self._unwrap_json(
+            self._client.get(
+                self._url("/v3/admin/ai/skills"),
+                params={"namespaceId": self.namespace_id, "skillName": name},
+                headers=self._headers(),
+            )
+        )
+        return data if isinstance(data, dict) else {}
+
+    def download_skill_zip(
+        self,
+        name: str,
+        *,
+        version: str | None = None,
+        label: str = "latest",
+        admin: bool = False,
+    ) -> bytes:
+        if admin and version:
+            response = self._client.get(
+                self._url("/v3/admin/ai/skills/version/download"),
+                params={"namespaceId": self.namespace_id, "skillName": name, "version": version},
+                headers=self._headers(),
+            )
+        else:
+            params = {"namespaceId": self.namespace_id, "name": name}
+            if version:
+                params["version"] = version
+            elif label:
+                params["label"] = label
+            response = self._client.get(
+                self._url("/v3/client/ai/skills"),
+                params=params,
+                headers=self._headers(),
+            )
+        response.raise_for_status()
+        return response.content
+
+    def upload_skill_zip(
+        self,
+        *,
+        zip_bytes: bytes,
+        filename: str,
+        overwrite: bool,
+        target_version: str | None,
+    ) -> str:
+        data: dict[str, str] = {
+            "namespaceId": self.namespace_id,
+            "overwrite": "true" if overwrite else "false",
+        }
+        if target_version:
+            data["targetVersion"] = target_version
+        response = self._client.post(
+            self._url("/v3/admin/ai/skills/upload"),
+            data=data,
+            files={"file": (filename, zip_bytes, "application/zip")},
+            headers=self._headers(),
+        )
+        result = self._unwrap_json(response)
+        return str(result or "")
+
+    def submit(self, name: str, version: str) -> str:
+        result = self._unwrap_json(
+            self._client.post(
+                self._url("/v3/admin/ai/skills/submit"),
+                data={"namespaceId": self.namespace_id, "skillName": name, "version": version},
+                headers=self._headers(),
+            )
+        )
+        return str(result or "")
+
+    def publish(self, name: str, version: str, *, update_latest_label: bool = True) -> None:
+        self._unwrap_json(
+            self._client.post(
+                self._url("/v3/admin/ai/skills/publish"),
+                data={
+                    "namespaceId": self.namespace_id,
+                    "skillName": name,
+                    "version": version,
+                    "updateLatestLabel": "true" if update_latest_label else "false",
+                },
+                headers=self._headers(),
+            )
+        )
+
+
+def _bundle_to_nacos_zip(skill_name: str, bundle_files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for rel_path, data in sorted(bundle_files.items()):
+            zf.writestr(f"{skill_name}/{rel_path}", data)
+    return buf.getvalue()
+
+
+def _nacos_zip_to_bundle(zip_bytes: bytes) -> dict[str, bytes]:
+    bundle: dict[str, bytes] = {}
+    with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
+        names = [name for name in zf.namelist() if name and not name.endswith("/")]
+        roots = {name.split("/", 1)[0] for name in names if "/" in name}
+        strip_root = len(roots) == 1 and all("/" in name for name in names)
+        for name in names:
+            rel = name.split("/", 1)[1] if strip_root else name
+            if not rel:
+                continue
+            bundle[rel] = zf.read(name)
+    return bundle
+
+
+def _parse_version_number(version: str | None) -> int:
+    raw = str(version or "").strip()
+    if raw.startswith("v"):
+        raw = raw[1:]
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
+def _next_version(summary: dict[str, Any], detail: dict[str, Any] | None = None) -> str:
+    versions: list[str] = []
+    labels = summary.get("labels")
+    if isinstance(labels, dict):
+        versions.extend(str(v) for v in labels.values() if v)
+    for field in ("editingVersion", "reviewingVersion", "version"):
+        if summary.get(field):
+            versions.append(str(summary[field]))
+    for item in (detail or {}).get("versions") or []:
+        if isinstance(item, dict) and item.get("version"):
+            versions.append(str(item["version"]))
+    next_num = max([_parse_version_number(v) for v in versions] or [0]) + 1
+    return f"v{next_num}"
+
+
+class NacosSkillHub:
+    """SkillHub-compatible facade backed by Nacos Skill APIs."""
+
+    def __init__(
+        self,
+        *,
+        client: NacosSkillClient,
+        user_alias: str = "",
+        label: str = "latest",
+    ) -> None:
+        self._client = client
+        self._user_alias = user_alias or os.environ.get("USER", "anonymous")
+        self._label = str(label or "latest")
+
+    @classmethod
+    def from_config(cls, config) -> "NacosSkillHub":
+        client = NacosSkillClient(
+            server=str(getattr(config, "sharing_nacos_server", "") or getattr(config, "sharing_endpoint", "") or ""),
+            namespace_id=str(getattr(config, "sharing_nacos_namespace_id", "") or "public"),
+            access_token=str(getattr(config, "sharing_nacos_access_token", "") or ""),
+            username=str(getattr(config, "sharing_nacos_username", "") or ""),
+            password=str(getattr(config, "sharing_nacos_password", "") or ""),
+        )
+        return cls(
+            client=client,
+            user_alias=str(getattr(config, "sharing_user_alias", "") or ""),
+            label=str(getattr(config, "sharing_nacos_label", "") or "latest"),
+        )
+
+    def _remote_by_name(self) -> dict[str, dict[str, Any]]:
+        return {str(item.get("name") or ""): item for item in self._client.list_skills() if item.get("name")}
+
+    @staticmethod
+    def _local_bundle_matches_remote(skill_dir: str, remote_bundle: dict[str, bytes]) -> bool:
+        local_bundle, _records, local_sha = read_skill_bundle_with_meta(skill_dir)
+        return bool(local_bundle) and local_sha == bundle_tree_sha256(remote_bundle)
+
+    def _download_skill_bundle(self, name: str, rec: dict[str, Any]) -> dict[str, bytes]:
+        labels = rec.get("labels") if isinstance(rec.get("labels"), dict) else {}
+        version = labels.get(self._label)
+        zip_bytes = self._client.download_skill_zip(name, version=version, label=self._label)
+        return _nacos_zip_to_bundle(zip_bytes)
+
+    def list_remote(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for item in self._client.list_skills():
+            labels = item.get("labels") if isinstance(item.get("labels"), dict) else {}
+            out.append({
+                **item,
+                "version": labels.get(self._label) or item.get("version") or item.get("reviewingVersion") or "",
+                "uploaded_by": item.get("owner") or item.get("from") or "nacos",
+                "uploaded_at": item.get("updatedAt") or item.get("updateTime") or "",
+                "category": item.get("category") or "general",
+            })
+        return out
+
+    def push_skills(
+        self,
+        skills_dir: str,
+        skill_filter: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        if _is_hermes_skill_root(skills_dir):
+            paths = sorted(Path(skills_dir).glob("**/SKILL.md"))
+        else:
+            paths = sorted(Path(skills_dir).glob("*/SKILL.md"))
+        if not paths:
+            return {"uploaded": 0, "skipped": 0, "filtered": 0, "submitted": 0, "published": 0, "total_local": 0}
+
+        remote = self._remote_by_name()
+        stats = (skill_filter or {}).get("stats", {})
+        min_inj = (skill_filter or {}).get("min_injections", 0)
+        min_eff = (skill_filter or {}).get("min_effectiveness", 0.0)
+        use_filter = skill_filter is not None
+        uploaded = skipped = filtered = submitted = 0
+
+        for path in paths:
+            skill_name = path.parent.name
+            skill_dir = str(path.parent)
+            if use_filter and skill_name in stats:
+                entry = stats[skill_name]
+                inj = entry.get("inject_count", 0)
+                eff = entry.get("effectiveness", 0.5)
+                if inj >= min_inj and eff < min_eff:
+                    filtered += 1
+                    continue
+
+            bundle_files, _bundle_records, _tree_sha = read_skill_bundle_with_meta(skill_dir)
+            remote_rec = remote.get(skill_name)
+            if remote_rec:
+                try:
+                    remote_bundle = self._download_skill_bundle(skill_name, remote_rec)
+                    if self._local_bundle_matches_remote(skill_dir, remote_bundle):
+                        skipped += 1
+                        continue
+                except Exception as exc:
+                    logger.info("[NacosSkillHub] remote comparison skipped for %s: %s", skill_name, exc)
+
+            detail = self._client.get_skill(skill_name) if remote_rec else {}
+            target_version = _next_version(remote_rec or {}, detail)
+            zip_bytes = _bundle_to_nacos_zip(skill_name, bundle_files)
+            self._client.upload_skill_zip(
+                zip_bytes=zip_bytes,
+                filename=f"{skill_name}-{target_version}.zip",
+                overwrite=True,
+                target_version=target_version,
+            )
+            uploaded += 1
+
+            self._client.submit(skill_name, target_version)
+            submitted += 1
+
+            logger.info("[NacosSkillHub] pushed skill %s as %s", skill_name, target_version)
+
+        return {
+            "uploaded": uploaded,
+            "skipped": skipped,
+            "filtered": filtered,
+            "submitted": submitted,
+            "published": 0,
+            "total_local": len(paths),
+        }
+
+    def publish_skill(self, name: str, version: str, *, update_latest_label: bool = True) -> dict[str, Any]:
+        self._client.publish(name, version, update_latest_label=update_latest_label)
+        return {
+            "skill_name": name,
+            "version": version,
+            "published": 1,
+            "updated_latest_label": bool(update_latest_label),
+        }
+
+    def pull_skills(
+        self,
+        skills_dir: str,
+        mirror: bool = True,
+        skip_names: Optional[Collection[str]] = None,
+        include_names: Optional[Collection[str]] = None,
+    ) -> dict[str, Any]:
+        os.makedirs(skills_dir, exist_ok=True)
+        remote = self._remote_by_name()
+        include_set = {str(name or "").strip() for name in (include_names or []) if str(name or "").strip()}
+        skip_set = {str(name or "").strip() for name in (skip_names or []) if str(name or "").strip()}
+        if include_set:
+            remote = {name: rec for name, rec in remote.items() if name in include_set}
+            mirror = False
+        if not remote:
+            return {
+                "downloaded": 0,
+                "skipped": 0,
+                "deleted": 0,
+                "total_remote": 0,
+                "restored_from_backup": False,
+                "backup_dir": "",
+            }
+
+        local_dirs_by_name = {}
+        for skill_md in Path(skills_dir).glob("**/SKILL.md" if _is_hermes_skill_root(skills_dir) else "*/SKILL.md"):
+            local_dirs_by_name.setdefault(skill_md.parent.name, []).append(str(skill_md.parent))
+
+        downloaded = skipped = deleted = failed = 0
+        failed_names: list[str] = []
+        for name, rec in remote.items():
+            category = str(rec.get("category", "general") or "general")
+            target_dir = _skill_dir_for_root(skills_dir, name, category)
+            if name in skip_set and os.path.exists(os.path.join(target_dir, "SKILL.md")):
+                skipped += 1
+                continue
+            try:
+                bundle = self._download_skill_bundle(name, rec)
+            except Exception as exc:
+                failed += 1
+                failed_names.append(name)
+                logger.warning("[NacosSkillHub] failed to download skill %s: %s", name, exc)
+                continue
+            if os.path.isdir(target_dir) and self._local_bundle_matches_remote(target_dir, bundle):
+                skipped += 1
+                continue
+            write_skill_bundle(target_dir, bundle, clean=True)
+            downloaded += 1
+
+        if mirror:
+            for name, dirs in local_dirs_by_name.items():
+                if name in remote:
+                    continue
+                for skill_dir in dirs:
+                    shutil.rmtree(skill_dir)
+                    deleted += 1
+
+        return {
+            "downloaded": downloaded,
+            "skipped": skipped,
+            "deleted": deleted,
+            "failed": failed,
+            "failed_names": failed_names,
+            "total_remote": len(remote),
+            "restored_from_backup": False,
+            "backup_dir": "",
+        }
+
+    def sync_skills(self, skills_dir: str) -> dict[str, dict[str, Any]]:
+        pull_result = self.pull_skills(skills_dir, mirror=False)
+        push_result = self.push_skills(skills_dir)
+        return {"pull": pull_result, "push": push_result}
+
+    def build_manifest_record(self, skill_name: str, bundle_files: dict[str, bytes]) -> dict[str, Any]:
+        skill_md = bundle_entrypoint_text(bundle_files)
+        content_sha = hashlib.sha256(skill_md.encode("utf-8")).hexdigest()
+        return {
+            "name": skill_name,
+            "sha256": content_sha,
+            "tree_sha256": bundle_tree_sha256(bundle_files),
+            "format": "bundle_v1",
+            "entrypoint": "SKILL.md",
+            "files": bundle_file_records(bundle_files),
+            "uploaded_by": self._user_alias,
+            "uploaded_at": datetime.now(timezone.utc).isoformat(),
+        }

--- a/skillclaw/skill_hub.py
+++ b/skillclaw/skill_hub.py
@@ -26,7 +26,7 @@ from typing import Any, Collection, Optional
 
 from evolve_server.core.skill_registry import SkillIDRegistry
 
-from .object_store import build_object_store, is_not_found_error
+from .object_store import build_object_store, is_not_found_error, normalize_backend
 from .skill_bundle import (
     bundle_entrypoint_bytes,
     bundle_file_records,
@@ -92,6 +92,10 @@ class SkillHub:
     @classmethod
     def from_config(cls, config) -> "SkillHub":
         backend = str(getattr(config, "sharing_backend", "") or "").strip().lower()
+        if backend == "nacos":
+            from .nacos_skill_hub import NacosSkillHub
+
+            return NacosSkillHub.from_config(config)
         endpoint = str(getattr(config, "sharing_endpoint", "") or "")
         bucket = str(getattr(config, "sharing_bucket", "") or "")
         access_key_id = str(getattr(config, "sharing_access_key_id", "") or "")
@@ -99,6 +103,48 @@ class SkillHub:
         local_root = str(getattr(config, "sharing_local_root", "") or "")
         return cls(
             backend=backend or ("local" if local_root else "s3" if (bucket or endpoint) else "oss"),
+            endpoint=endpoint,
+            bucket=bucket,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            region=str(getattr(config, "sharing_region", "") or ""),
+            session_token=str(getattr(config, "sharing_session_token", "") or ""),
+            local_root=local_root,
+            group_id=getattr(config, "sharing_group_id", "default"),
+            user_alias=getattr(config, "sharing_user_alias", ""),
+        )
+
+    @classmethod
+    def object_storage_from_config(cls, config) -> Optional["SkillHub"]:
+        """Build the legacy object-store hub for non-skill artifacts.
+
+        ``sharing.backend=nacos`` selects only the Skill registry. Sessions,
+        validation jobs, and other non-skill artifacts must continue to use
+        local/OSS/S3 object storage when that storage is explicitly configured.
+        """
+        sharing_backend = str(getattr(config, "sharing_backend", "") or "").strip().lower()
+        backend = str(getattr(config, "sharing_session_backend", "") or "").strip().lower()
+        if not backend and sharing_backend != "nacos":
+            backend = sharing_backend
+
+        endpoint = str(getattr(config, "sharing_endpoint", "") or "")
+        bucket = str(getattr(config, "sharing_bucket", "") or "")
+        access_key_id = str(getattr(config, "sharing_access_key_id", "") or "")
+        secret_access_key = str(getattr(config, "sharing_secret_access_key", "") or "")
+        local_root = str(getattr(config, "sharing_local_root", "") or "")
+
+        resolved = normalize_backend(backend, endpoint=endpoint, local_root=local_root)
+        if resolved == "nacos":
+            resolved = ""
+        if not resolved and local_root:
+            resolved = "local"
+        if not resolved and sharing_backend != "nacos" and (bucket or endpoint):
+            resolved = "oss" if endpoint and "aliyuncs.com" in endpoint else "s3"
+        if not resolved:
+            return None
+
+        return cls(
+            backend=resolved,
             endpoint=endpoint,
             bucket=bucket,
             access_key_id=access_key_id,

--- a/skillclaw/validation_store.py
+++ b/skillclaw/validation_store.py
@@ -55,23 +55,15 @@ class ValidationStore:
 
     @classmethod
     def from_config(cls, config) -> "ValidationStore":
-        backend = str(getattr(config, "sharing_backend", "") or "").strip().lower()
-        endpoint = str(getattr(config, "sharing_endpoint", "") or "")
-        bucket = str(getattr(config, "sharing_bucket", "") or "")
-        access_key_id = str(getattr(config, "sharing_access_key_id", "") or "")
-        secret_access_key = str(getattr(config, "sharing_secret_access_key", "") or "")
-        local_root = str(getattr(config, "sharing_local_root", "") or "")
-        return cls(
-            backend=backend or ("local" if local_root else "s3" if (bucket or endpoint) else "oss"),
-            endpoint=endpoint,
-            bucket=bucket,
-            access_key_id=access_key_id,
-            secret_access_key=secret_access_key,
-            region=str(getattr(config, "sharing_region", "") or ""),
-            session_token=str(getattr(config, "sharing_session_token", "") or ""),
-            local_root=local_root,
-            group_id=str(getattr(config, "sharing_group_id", "default") or "default"),
-        )
+        from .skill_hub import SkillHub
+
+        hub = SkillHub.object_storage_from_config(config)
+        if hub is None:
+            raise ValueError("validation storage requires local/OSS/S3; Nacos stores skills only")
+        store = cls.__new__(cls)
+        store._bucket = hub._bucket
+        store._group_id = str(getattr(config, "sharing_group_id", "default") or "default")
+        return store
 
     def _prefix(self) -> str:
         return f"{self._group_id}/"

--- a/tests/test_nacos_skill_hub.py
+++ b/tests/test_nacos_skill_hub.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+
+from skillclaw.nacos_skill_hub import NacosSkillClient, NacosSkillHub, _bundle_to_nacos_zip
+
+
+SKILL_MD = """---
+name: demo-skill
+description: Demo skill
+---
+
+# Demo Skill
+"""
+
+
+def _write_skill(root: Path, body: str = SKILL_MD) -> None:
+    skill_dir = root / "demo-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+
+
+def _json(data):
+    return httpx.Response(200, json={"code": 0, "data": data})
+
+
+def test_nacos_push_uploads_then_submits_without_publish(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir)
+    calls: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append((request.method, request.url.path))
+        if request.method == "GET" and request.url.path == "/v3/admin/ai/skills/list":
+            return _json({"totalCount": 0, "pageItems": []})
+        if request.method == "POST" and request.url.path == "/v3/admin/ai/skills/upload":
+            assert request.url.params.get("targetVersion") is None
+            assert b'name="targetVersion"' in request.content
+            assert b"v1" in request.content
+            return _json("demo-skill")
+        if request.method == "POST" and request.url.path == "/v3/admin/ai/skills/submit":
+            assert request.content == b"namespaceId=public&skillName=demo-skill&version=v1"
+            return _json("v1")
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = NacosSkillClient(
+        server="http://nacos.test",
+        namespace_id="public",
+        transport=httpx.MockTransport(handler),
+    )
+    hub = NacosSkillHub(client=client)
+
+    result = hub.push_skills(str(skills_dir))
+
+    assert result["uploaded"] == 1
+    assert result["submitted"] == 1
+    assert result["published"] == 0
+    assert ("POST", "/v3/admin/ai/skills/publish") not in calls
+
+
+def test_nacos_publish_is_explicit_after_review() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append((request.method, request.url.path))
+        if request.url.path == "/v3/admin/ai/skills/publish":
+            assert b"updateLatestLabel=true" in request.content
+            return _json("ok")
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = NacosSkillClient(
+        server="http://nacos.test",
+        namespace_id="public",
+        transport=httpx.MockTransport(handler),
+    )
+    hub = NacosSkillHub(client=client)
+
+    result = hub.publish_skill("demo-skill", "v1")
+
+    assert result["published"] == 1
+    assert result["updated_latest_label"] is True
+    assert ("POST", "/v3/admin/ai/skills/publish") in calls
+
+
+def test_nacos_pull_downloads_latest_zip(tmp_path: Path) -> None:
+    zip_bytes = _bundle_to_nacos_zip(
+        "demo-skill",
+        {
+            "SKILL.md": SKILL_MD.encode("utf-8"),
+            "references/guide.md": b"hello\n",
+        },
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/admin/ai/skills/list":
+            return _json(
+                {
+                    "totalCount": 1,
+                    "pageItems": [
+                        {
+                            "name": "demo-skill",
+                            "description": "Demo skill",
+                            "labels": {"latest": "v3"},
+                        }
+                    ],
+                }
+            )
+        if request.url.path == "/v3/client/ai/skills":
+            assert request.url.params["name"] == "demo-skill"
+            assert request.url.params["version"] == "v3"
+            return httpx.Response(200, content=zip_bytes)
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = NacosSkillClient(
+        server="http://nacos.test",
+        namespace_id="public",
+        transport=httpx.MockTransport(handler),
+    )
+    hub = NacosSkillHub(client=client)
+    restored = tmp_path / "restored"
+
+    result = hub.pull_skills(str(restored))
+
+    assert result["downloaded"] == 1
+    assert (restored / "demo-skill" / "SKILL.md").read_text(encoding="utf-8") == SKILL_MD
+    assert (restored / "demo-skill" / "references" / "guide.md").read_bytes() == b"hello\n"
+
+
+def test_nacos_pull_skips_failed_download_and_continues(tmp_path: Path) -> None:
+    zip_bytes = _bundle_to_nacos_zip("demo-skill", {"SKILL.md": SKILL_MD.encode("utf-8")})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/admin/ai/skills/list":
+            return _json(
+                {
+                    "totalCount": 2,
+                    "pageItems": [
+                        {
+                            "name": "broken-skill",
+                            "description": "Missing latest label",
+                            "labels": {},
+                        },
+                        {
+                            "name": "demo-skill",
+                            "description": "Demo skill",
+                            "labels": {"latest": "v1"},
+                        },
+                    ],
+                }
+            )
+        if request.url.path == "/v3/client/ai/skills":
+            if request.url.params["name"] == "broken-skill":
+                return httpx.Response(404)
+            assert request.url.params["name"] == "demo-skill"
+            return httpx.Response(200, content=zip_bytes)
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = NacosSkillClient(
+        server="http://nacos.test",
+        namespace_id="public",
+        transport=httpx.MockTransport(handler),
+    )
+    hub = NacosSkillHub(client=client)
+    restored = tmp_path / "restored"
+
+    result = hub.pull_skills(str(restored))
+
+    assert result["downloaded"] == 1
+    assert result["failed"] == 1
+    assert result["failed_names"] == ["broken-skill"]
+    assert (restored / "demo-skill" / "SKILL.md").read_text(encoding="utf-8") == SKILL_MD
+    assert not (restored / "broken-skill").exists()


### PR DESCRIPTION
## Summary

- Add a Nacos-backed skill hub with push, pull, sync, conflict handling, and local config persistence.
- Wire Nacos skill sync into CLI, API server/startup, workflow/session paths, and validation metadata.
- Add a lifecycle demo script plus tests covering Nacos skill hub behavior.

## Tests

- `pytest tests/test_nacos_skill_hub.py` (blocked locally: `ModuleNotFoundError: No module named 'httpx'` in the active Python environment)