### PR TITLE
Add Atlas Cloud provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ skillclaw setup
 
 The setup wizard prompts for the provider, model, local skills directory, PRM settings, optional CLI agent integration, and optional shared storage.
 
+If you use Atlas Cloud as the upstream OpenAI-compatible provider, choose `atlascloud`, keep the default API base `https://api.atlascloud.ai/v1`, and enter your Atlas Cloud API key when prompted. The preset uses chat-compatible forwarding so Codex clients can use SkillClaw's Responses-to-chat bridge.
+
 For a minimal first run:
 
 - choose `none` for the CLI agent if you do not want SkillClaw to auto-configure an external agent yet

--- a/assets/README_ZH.md
+++ b/assets/README_ZH.md
@@ -208,6 +208,8 @@ skillclaw setup
 
 设置向导会依次提示你选择 provider、模型、本地 skills 目录、PRM 设置、可选的 CLI agent 集成、以及可选的共享存储。
 
+如果你使用 Atlas Cloud 作为上游 OpenAI 兼容 provider，可以选择 `atlascloud`，保留默认 API base `https://api.atlascloud.ai/v1`，并在提示时输入你的 Atlas Cloud API key。该预设默认走 chat-compatible 转发，因此 Codex 客户端也可以通过 SkillClaw 的 Responses-to-chat 桥接使用。
+
 第一次最小化验证时，推荐这样选：
 
 - `CLI agent` 选 `none`，先不要自动改外部 agent 配置

--- a/client_env.example.sh
+++ b/client_env.example.sh
@@ -13,6 +13,11 @@
 export OPENAI_BASE_URL="https://your-model-gateway.example/v1"
 export OPENAI_API_KEY="your-openai-api-key"
 
+# Atlas Cloud can be used as an OpenAI-compatible upstream:
+# export ATLASCLOUD_API_KEY="your-atlascloud-api-key"
+# export OPENAI_BASE_URL="https://api.atlascloud.ai/v1"
+# export OPENAI_API_KEY="$ATLASCLOUD_API_KEY"
+
 # Convenience values for shared-skill setup discussions or local wrappers.
 export OSS_ENDPOINT="https://oss-cn-hangzhou.aliyuncs.com"
 export OSS_BUCKET="skillclaw-shared-skills"

--- a/skillclaw/setup_wizard.py
+++ b/skillclaw/setup_wizard.py
@@ -35,6 +35,10 @@ _PROVIDER_PRESETS = {
         "api_base": "https://openrouter.ai/api/v1",
         "model_id": "google/gemini-2.5-pro",
     },
+    "atlascloud": {
+        "api_base": "https://api.atlascloud.ai/v1",
+        "model_id": "deepseek-ai/DeepSeek-V3.1",
+    },
     "bedrock": {
         "api_base": "",
         "model_id": "us.anthropic.claude-sonnet-4-6",
@@ -43,6 +47,10 @@ _PROVIDER_PRESETS = {
         "api_base": "",
         "model_id": "",
     },
+}
+_PROVIDER_CHOICES = ["kimi", "qwen", "openai", "minimax", "novita", "openrouter", "atlascloud", "bedrock", "custom"]
+_PROVIDER_DEFAULT_API_MODE = {
+    "atlascloud": "chat",
 }
 
 
@@ -102,6 +110,10 @@ def _infer_existing_sharing_backend(current_sharing: dict) -> str:
     return "s3"
 
 
+def _default_llm_api_mode(provider: str, claw_type: str) -> str:
+    return _PROVIDER_DEFAULT_API_MODE.get(provider, default_llm_api_mode_for_claw(claw_type))
+
+
 class SetupWizard:
     """Interactive configuration wizard."""
 
@@ -131,9 +143,10 @@ class SetupWizard:
         current_provider = current_llm.get("provider", "custom")
         provider = _prompt_choice(
             "LLM provider",
-            ["kimi", "qwen", "openai", "minimax", "novita", "openrouter", "bedrock", "custom"],
+            _PROVIDER_CHOICES,
             default=current_provider,
         )
+        provider_unchanged = current_provider == provider
         preset = _PROVIDER_PRESETS[provider]
         openrouter_config: dict = existing.get("openrouter", {})
         if provider == "bedrock":
@@ -141,25 +154,25 @@ class SetupWizard:
             api_key = ""
             model_id = _prompt(
                 "Bedrock model ID (inference profile)",
-                default=current_llm.get("model_id") or preset["model_id"],
+                default=(current_llm.get("model_id") if provider_unchanged else "") or preset["model_id"],
             )
             bedrock_region = _prompt(
                 "AWS region",
-                default=current_llm.get("bedrock_region", "us-east-1"),
+                default=(current_llm.get("bedrock_region") if provider_unchanged else "") or "us-east-1",
             )
         else:
             bedrock_region = ""
             api_base = _prompt(
                 "API base URL [http://api.example.com/v1]",
-                default=current_llm.get("api_base") or preset["api_base"],
+                default=(current_llm.get("api_base") if provider_unchanged else "") or preset["api_base"],
             )
             model_id = _prompt(
                 "Model ID",
-                default=current_llm.get("model_id") or preset["model_id"],
+                default=(current_llm.get("model_id") if provider_unchanged else "") or preset["model_id"],
             )
             api_key = _prompt(
                 "API key",
-                default=current_llm.get("api_key", ""),
+                default=current_llm.get("api_key", "") if provider_unchanged else "",
                 hide=True,
             )
 
@@ -361,8 +374,11 @@ class SetupWizard:
         proxy_config["port"] = proxy_port
         proxy_config.setdefault("host", "0.0.0.0")
         proxy_config["served_model_name"] = served_model_name or "skillclaw-model"
-        default_api_mode = default_llm_api_mode_for_claw(claw_type)
-        llm_api_mode = str(current_llm.get("api_mode", default_api_mode) or default_api_mode)
+        default_api_mode = _default_llm_api_mode(provider, claw_type)
+        if provider_unchanged:
+            llm_api_mode = str(current_llm.get("api_mode", default_api_mode) or default_api_mode)
+        else:
+            llm_api_mode = default_api_mode
         data = {
             "claw_type": claw_type,
             "llm": {

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -39,3 +39,51 @@ def test_setup_wizard_preserves_existing_llm_api_mode(monkeypatch, tmp_path):
     SetupWizard().run()
 
     assert saved["llm"]["api_mode"] == "responses"
+
+
+def test_setup_wizard_atlascloud_preset_uses_chat_bridge(monkeypatch, tmp_path):
+    saved = {}
+
+    class FakeConfigStore:
+        config_file = tmp_path / "config.yaml"
+
+        def exists(self):
+            return True
+
+        def load(self):
+            return {
+                "claw_type": "codex",
+                "llm": {
+                    "provider": "openai",
+                    "model_id": "gpt-4o",
+                    "api_base": "https://api.openai.com/v1",
+                    "api_key": "upstream-key",
+                    "api_mode": "responses",
+                },
+                "proxy": {"port": 30000, "served_model_name": "skillclaw-model"},
+                "skills": {"enabled": False, "dir": str(tmp_path / "skills")},
+                "prm": {"enabled": False},
+                "sharing": {"enabled": False},
+            }
+
+        def save(self, data):
+            saved.update(data)
+
+    def choose_atlascloud_provider(msg, choices, default=""):
+        if msg == "LLM provider":
+            return "atlascloud"
+        return default
+
+    monkeypatch.setattr(setup_wizard, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr(setup_wizard, "_prompt_choice", choose_atlascloud_provider)
+    monkeypatch.setattr(setup_wizard, "_prompt", lambda msg, default="", hide=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_bool", lambda msg, default=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_int", lambda msg, default=0: default)
+
+    SetupWizard().run()
+
+    assert saved["llm"]["provider"] == "atlascloud"
+    assert saved["llm"]["api_base"] == "https://api.atlascloud.ai/v1"
+    assert saved["llm"]["model_id"] == "deepseek-ai/DeepSeek-V3.1"
+    assert saved["llm"]["api_key"] == ""
+    assert saved["llm"]["api_mode"] == "chat"


### PR DESCRIPTION
## Summary
- add an `atlascloud` setup wizard preset for the OpenAI-compatible Atlas Cloud endpoint
- reset provider-specific defaults when switching providers so old base URLs, models, and API keys are not carried over
- document the minimal setup and optional environment fallback

## Tests
- `python3 -m pytest tests/test_setup_wizard.py`
- `python3 -m py_compile skillclaw/setup_wizard.py skillclaw/config_store.py tests/test_setup_wizard.py`