### PR TITLE
fix(config): wire prm.temperature from config.yaml to PRMScorer

### DIFF
--- a/skillclaw/config_store.py
+++ b/skillclaw/config_store.py
@@ -61,6 +61,7 @@ _DEFAULTS: dict = {
         "url": "",
         "model": "",
         "api_key": "",
+        "temperature": 0.6,
     },
     "sharing": {
         "enabled": False,
@@ -337,7 +338,8 @@ class ConfigStore:
         prm_url = str(prm.get("url", "") or llm_api_base)
         prm_model = str(prm.get("model", "") or llm_model_id or "gpt-5.2")
         prm_api_key = str(prm.get("api_key", "") or llm_api_key)
-        prm_temperature = float(prm.get("temperature", 0.6) or 0.6)
+        _prm_temperature = prm.get("temperature")
+        prm_temperature = float(_prm_temperature) if _prm_temperature is not None else 0.6
 
         skills_dir = resolve_skills_dir(
             skills.get("dir", str(_DEFAULT_SKILLS_DIR)),

--- a/skillclaw/config_store.py
+++ b/skillclaw/config_store.py
@@ -337,6 +337,7 @@ class ConfigStore:
         prm_url = str(prm.get("url", "") or llm_api_base)
         prm_model = str(prm.get("model", "") or llm_model_id or "gpt-5.2")
         prm_api_key = str(prm.get("api_key", "") or llm_api_key)
+        prm_temperature = float(prm.get("temperature", 0.6) or 0.6)
 
         skills_dir = resolve_skills_dir(
             skills.get("dir", str(_DEFAULT_SKILLS_DIR)),
@@ -377,6 +378,7 @@ class ConfigStore:
             prm_url=prm_url,
             prm_model=prm_model,
             prm_api_key=prm_api_key,
+            prm_temperature=prm_temperature,
             # Model
             model_name=llm.get("model_id") or "Qwen/Qwen3-4B",
             # Claw

--- a/tests/test_prm_temperature_config.py
+++ b/tests/test_prm_temperature_config.py
@@ -1,0 +1,49 @@
+"""``prm.temperature`` in config.yaml must reach ``SkillClawConfig.prm_temperature``.
+
+Regression coverage for the config bridge: the field existed but was never
+wired from YAML, and the first wiring attempt silently rewrote an explicit
+``temperature: 0`` to the default via an ``or``-guard. These cases pin the
+correct behavior: configured values pass through (including falsy-but-valid
+0), and the default only applies when the key is absent.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from skillclaw.config_store import ConfigStore
+
+
+def _store(tmp_path: Path, prm: dict) -> ConfigStore:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "llm": {"provider": "openai", "model_id": "k3", "api_base": "https://example.invalid/v1"},
+                "prm": prm,
+            }
+        )
+    )
+    return ConfigStore(cfg)
+
+
+def test_prm_temperature_from_config(tmp_path):
+    store = _store(tmp_path, {"enabled": True, "model": "k3", "temperature": 1})
+    assert store.to_skillclaw_config().prm_temperature == 1
+
+
+def test_prm_temperature_fractional_value(tmp_path):
+    store = _store(tmp_path, {"enabled": True, "model": "gpt-5.2", "temperature": 0.2})
+    assert store.to_skillclaw_config().prm_temperature == 0.2
+
+
+def test_prm_temperature_zero_is_honored(tmp_path):
+    """An explicit 0 (deterministic scoring) must not be rewritten to 0.6."""
+    store = _store(tmp_path, {"enabled": True, "model": "gpt-5.2", "temperature": 0})
+    assert store.to_skillclaw_config().prm_temperature == 0
+
+
+def test_prm_temperature_default_when_unset(tmp_path):
+    store = _store(tmp_path, {"enabled": True, "model": "gpt-5.2"})
+    assert store.to_skillclaw_config().prm_temperature == 0.6


### PR DESCRIPTION
## Problem

`SkillClawConfig.prm_temperature` exists (default 0.6) but `ConfigStore.to_skillclaw_config()` never populates it from the `prm` section of `config.yaml` — every other prm key (`provider`, `url`, `model`, `api_key`, `enabled`) is mapped, temperature is silently dropped. PRM scoring therefore always sends `temperature=0.6` upstream.

Models with sampling constraints reject this. kimi **k3** only accepts `temperature=1`, so every PRM vote fails:

```
[PRMScorer] query failed (vote 1): Error code: 400 - {'error': {'message': 'invalid temperature: only 1 is allowed for this model'}}
```

All votes fail → PRM scoring is silently disabled for any temperature-restricted upstream.

## Fix

Two lines: read `prm.temperature` (default 0.6, unchanged) in `to_skillclaw_config()` and pass it through to `SkillClawConfig`.

The key is already user-settable via the existing generic CLI — `skillclaw config prm.temperature 1` round-trips through `ConfigStore.get/set` — so no CLI changes are needed; the setting is now actually honored.

Not hard-coded: each deployment sets the value its model requires (`prm.temperature: 1` for k3, anything else for other models); 0.6 remains the default.

## Verification

- `skillclaw config prm.temperature 1` → `to_skillclaw_config().prm_temperature == 1.0` (verified against a live config with `prm.model: k3`)
- Daemon restarted; no more `invalid temperature` 400s in the PRM scorer path
- Existing behavior unchanged when the key is absent (default 0.6)