### PR TITLE
feat: support Hermes-managed Codex OAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Thumbs.db
 # Environment
 .env
 *.env.local
+.venv/
 
 # uv
 uv.lock

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The setup wizard prompts for the provider, model, local skills directory, PRM se
 For a minimal first run:
 
 - choose `none` for the CLI agent if you do not want SkillClaw to auto-configure an external agent yet
-- local skills at `~/.skillclaw/skills` for the generic setup path; if you choose Hermes, Codex, or Claude Code, the default local library becomes `~/.hermes/skills`, `~/.codex/skills`, or `~/.claude/skills`
+- local skills at `~/.skillclaw/skills` for the generic setup path; if you choose Hermes, Codex, or Claude Code, the default local library becomes `$HERMES_HOME/skills` (or `~/.hermes/skills` when unset), `~/.codex/skills`, or `~/.claude/skills`
 - disable shared storage if you only want to use the local proxy first
 - enable local shared storage only if you want to add the evolve server later on the same machine, and use a dedicated root such as `~/.skillclaw/local-share`
 - disable PRM if you want the cheapest first pass
@@ -239,8 +239,8 @@ If you already use Hermes, the client-side path is:
 1. Install Hermes first.
 2. Run `skillclaw setup` and choose `hermes` for `CLI agent to configure`.
 3. Keep `Proxy model name exposed to agents` as `skillclaw-model` unless you have a specific reason to change it.
-4. Start SkillClaw. On startup, SkillClaw rewrites `~/.hermes/config.yaml` to point Hermes at the local proxy.
-5. Hermes uses `~/.hermes/skills` as the default local skill library. SkillClaw prepares that directory automatically and copies in any missing legacy skills from `~/.skillclaw/skills`.
+4. Start SkillClaw. On startup, SkillClaw rewrites `$HERMES_HOME/config.yaml` (or `~/.hermes/config.yaml` when unset) to point Hermes at the local proxy.
+5. Hermes uses `$HERMES_HOME/skills` (or `~/.hermes/skills` when unset) as the default local skill library. SkillClaw prepares that directory automatically and copies in any missing legacy skills from `~/.skillclaw/skills`.
 6. If you want to inspect or undo the integration, use `skillclaw doctor hermes` and `skillclaw restore hermes`.
 
 Minimal verification:
@@ -258,6 +258,12 @@ skillclaw restore hermes
 ```
 
 `skillclaw doctor hermes` reports whether Hermes is pointed at the local proxy, whether the Hermes skills directory exists, whether legacy skills are still present, and that session boundaries still fall back to proxy-side heuristics unless Hermes sends explicit session headers.
+
+#### Hermes-managed ChatGPT / Codex OAuth
+
+Choose `hermes-openai-codex` as the upstream provider in `skillclaw setup` when Hermes already owns a ChatGPT/Codex OAuth login. SkillClaw resolves a fresh bearer through Hermes for each upstream request; it never stores the OAuth access or refresh token in `~/.skillclaw/config.yaml`.
+
+This route registers a named loopback provider with Hermes's native `codex_responses` wire mode, while SkillClaw owns the separate upstream `openai-codex` OAuth hop. Setup generates a local proxy key, forces `127.0.0.1`, and validates the Hermes OAuth login without storing OAuth access or refresh tokens. Start with `skillclaw start --daemon`, then verify the complete route with `skillclaw doctor hermes` and a `hermes chat` exact-reply query.
 
 ### Path B: Join an existing shared group
 

--- a/assets/README_ZH.md
+++ b/assets/README_ZH.md
@@ -211,7 +211,7 @@ skillclaw setup
 第一次最小化验证时，推荐这样选：
 
 - `CLI agent` 选 `none`，先不要自动改外部 agent 配置
-- `skills` 目录保持默认值 `~/.skillclaw/skills`；如果你选了 Hermes、Codex 或 Claude Code，默认技能库会变成 `~/.hermes/skills`、`~/.codex/skills` 或 `~/.claude/skills`
+- `skills` 目录保持默认值 `~/.skillclaw/skills`；如果你选了 Hermes、Codex 或 Claude Code，默认技能库会变成 `$HERMES_HOME/skills`（未设置时为 `~/.hermes/skills`）、`~/.codex/skills` 或 `~/.claude/skills`
 - 如果你只是想先验证代理能不能正常用，可以先关闭 shared storage
 - 如果你后面想在同一台机器上继续跑本地 evolver 闭环，就把 shared storage 打开并选 `local` backend，例如 `~/.skillclaw/local-share`
 - 如果你想先把成本压到最低，可以先关闭 PRM
@@ -238,8 +238,8 @@ curl "http://127.0.0.1:${PROXY_PORT}/healthz"
 1. 先安装 Hermes。
 2. 运行 `skillclaw setup`，在 `CLI agent to configure` 里选择 `hermes`。
 3. `Proxy model name exposed to agents` 保持 `skillclaw-model`，除非你明确知道自己为什么要改它。
-4. 启动 SkillClaw。启动时，SkillClaw 会自动改写 `~/.hermes/config.yaml`，把 Hermes 指到本地代理。
-5. Hermes 默认使用 `~/.hermes/skills` 作为本地技能库。SkillClaw 会自动准备好该目录，并把 `~/.skillclaw/skills` 中遗留的旧技能复制过来。
+4. 启动 SkillClaw。启动时，SkillClaw 会自动改写 `$HERMES_HOME/config.yaml`（未设置时为 `~/.hermes/config.yaml`），把 Hermes 指到本地代理。
+5. Hermes 默认使用 `$HERMES_HOME/skills`（未设置时为 `~/.hermes/skills`）作为本地技能库。SkillClaw 会自动准备好该目录，并把 `~/.skillclaw/skills` 中遗留的旧技能复制过来。
 6. 如果你想检查或撤销集成，使用 `skillclaw doctor hermes` 和 `skillclaw restore hermes`。
 
 最小验证命令：
@@ -257,6 +257,12 @@ skillclaw restore hermes
 ```
 
 `skillclaw doctor hermes` 会检查 Hermes 是否指向了本地代理、Hermes skills 目录是否存在、旧技能是否还在、以及会话边界是否仍回退到代理侧的启发式策略（除非 Hermes 发送了显式的 session header）。
+
+#### 使用 Hermes 管理的 ChatGPT / Codex OAuth
+
+如果 Hermes 已经持有 ChatGPT/Codex OAuth 登录，可在 `skillclaw setup` 中选择 `hermes-openai-codex`。SkillClaw 每次请求都通过 Hermes 临时解析访问令牌，不会把 OAuth access token 或 refresh token 写入 `~/.skillclaw/config.yaml`。
+
+该模式仅绑定本机回环地址，使用独立的本地代理密钥，并通过 Hermes 原生 `codex_responses` 传输。启动后使用 `skillclaw doctor hermes` 和一次 `hermes chat` 精确回复测试验证完整链路。
 
 ### 路径 B：加入一个已有的共享群组
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ server = [
     "oss2",
     "python-dotenv",
 ]
+# Test suite
+test = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+]
 # Everything
 all = [
     "skillclaw[embedding,evolve,sharing,server]",

--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -2655,10 +2655,14 @@ class SkillClawAPIServer:
 
         send_body = {k: v for k, v in body.items() if k not in _NON_STANDARD_BODY_KEYS}
         send_body["model"] = self.config.llm_model_id or body.get("model", "")
-        send_body["stream"] = stream
+        # Codex only accepts upstream SSE. The non-streaming first hop below
+        # consumes response.completed and returns its JSON response body.
+        send_body["stream"] = True if self.config.llm_provider == "hermes-openai-codex" else stream
         headers = dict(headers)
         if self.config.llm_provider == "hermes-openai-codex":
             send_body.pop("max_output_tokens", None)
+            # ChatGPT Codex Responses rejects persisted response storage.
+            send_body["store"] = False
             cache_scope_id = str(body.get("_skillclaw_codex_session_id") or "").strip()
             if cache_scope_id:
                 headers["session_id"] = cache_scope_id
@@ -2790,11 +2794,70 @@ class SkillClawAPIServer:
                 seen_tokens.add(failed_token)
             try:
                 async with httpx.AsyncClient(timeout=_llm_request_timeout_seconds()) as client:
-                    resp = await client.post(
-                        url,
-                        json=send_body,
-                        headers=headers,
-                    )
+                    if self.config.llm_provider == "hermes-openai-codex":
+                        async with client.stream("POST", url, json=send_body, headers=headers) as resp:
+                            if resp.status_code >= 400:
+                                await resp.aread()
+                            resp.raise_for_status()
+                            buffer = ""
+                            output_items: dict[int, dict[str, Any]] = {}
+                            async for chunk in resp.aiter_text():
+                                buffer += chunk
+                                while "\n" in buffer:
+                                    line, buffer = buffer.split("\n", 1)
+                                    if not line.startswith("data: "):
+                                        continue
+                                    raw = line[6:].strip()
+                                    if raw == "[DONE]":
+                                        continue
+                                    event = json.loads(raw)
+                                    output_index = int(event.get("output_index", 0) or 0)
+                                    if event.get("type") in {"response.output_item.added", "response.output_item.done"}:
+                                        item = event.get("item")
+                                        if isinstance(item, dict):
+                                            output_items[output_index] = item
+                                    elif event.get("type") in {
+                                        "response.output_text.delta",
+                                        "response.output_text.done",
+                                    }:
+                                        item = output_items.setdefault(
+                                            output_index,
+                                            {
+                                                "type": "message",
+                                                "role": "assistant",
+                                                "status": "completed",
+                                                "content": [],
+                                            },
+                                        )
+                                        content_index = int(event.get("content_index", 0) or 0)
+                                        content = item.get("content")
+                                        if not isinstance(content, list):
+                                            content = []
+                                            item["content"] = content
+                                        while len(content) <= content_index:
+                                            content.append({"type": "output_text", "text": "", "annotations": []})
+                                        part = content[content_index]
+                                        part["text"] = (
+                                            str(event.get("text") or "")
+                                            if event.get("type") == "response.output_text.done"
+                                            else str(part.get("text") or "") + str(event.get("delta") or "")
+                                        )
+                                    if event.get("type") in {
+                                        "response.completed",
+                                        "response.incomplete",
+                                        "response.failed",
+                                    }:
+                                        response = event.get("response")
+                                        if isinstance(response, dict):
+                                            if output_items and not response.get("output"):
+                                                response = {
+                                                    **response,
+                                                    "output": [item for _, item in sorted(output_items.items())],
+                                                }
+                                            return response
+                            raise RuntimeError("Codex stream ended before response.completed")
+
+                    resp = await client.post(url, json=send_body, headers=headers)
                     resp.raise_for_status()
                     return resp.json()
             except httpx.HTTPStatusError as e:

--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import copy
+import ipaddress
 import json
 import logging
 import os
@@ -47,9 +48,63 @@ _NON_STANDARD_BODY_KEYS = {
     "session_done",
     "turn_type",
     "_skillclaw_protocol",
+    "_skillclaw_codex_session_id",
 }
 _PROTOCOL_ANTHROPIC_MESSAGES = "anthropic_messages"
 _PROTOCOL_RESPONSES_COMPAT = "responses_compat"
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = str(host or "").strip().strip("[]")
+    if normalized.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _bearer_token(headers: dict[str, str]) -> str:
+    return headers.get("Authorization", "").removeprefix("Bearer ").strip()
+
+
+def _safe_upstream_error_text(response: Any, failed_token: str) -> str:
+    """Return bounded diagnostics without retaining an OAuth bearer."""
+    text = response.text[:200]
+    return text.replace(failed_token, "[REDACTED]") if failed_token else text
+
+
+def _recover_codex_auth(
+    headers: dict[str, str],
+    status_code: int,
+    seen_tokens: set[str],
+    *,
+    allow_auth_store_refresh: bool,
+) -> tuple[tuple[str, str, dict[str, str]] | None, bool]:
+    """Return an unseen pooled/refreshed credential and whether auth refresh ran."""
+    from .hermes_codex import recover_upstream, resolve_upstream
+
+    failed_token = _bearer_token(headers)
+    candidate = recover_upstream(failed_token, status_code=status_code)
+    if candidate is not None and candidate[1] not in seen_tokens:
+        return candidate, False
+    if status_code == 401 and allow_auth_store_refresh:
+        try:
+            candidate = resolve_upstream(force_refresh=True)
+        except Exception:
+            candidate = None
+        if candidate is not None and candidate[1] not in seen_tokens:
+            return candidate, True
+        return None, True
+    return None, False
+
+
+async def _prefetched_stream(first_chunk: bytes | None, stream: Any):
+    """Replay a prefetched chunk, then continue the original async stream."""
+    if first_chunk is not None:
+        yield first_chunk
+    async for chunk in stream:
+        yield chunk
 
 
 # ------------------------------------------------------------------ #
@@ -1434,6 +1489,8 @@ class SkillClawAPIServer:
         prm_scorer: Optional[PRMScorer] = None,
         last_request_tracker=None,
     ):
+        if config.llm_provider == "hermes-openai-codex" and not config.proxy_api_key:
+            raise ValueError("hermes-openai-codex requires proxy.api_key")
         self.config = config
         self._sampling_client = sampling_client
         self.skill_manager = skill_manager
@@ -1621,6 +1678,7 @@ class SkillClawAPIServer:
             authorization: Optional[str] = Header(default=None),
             x_session_id: Optional[str] = Header(default=None),
             codex_session_id: Optional[str] = Header(default=None, alias="session_id"),
+            x_client_request_id: Optional[str] = Header(default=None, alias="x-client-request-id"),
             x_turn_type: Optional[str] = Header(default=None),
             x_session_done: Optional[str] = Header(default=None),
         ):
@@ -1633,22 +1691,25 @@ class SkillClawAPIServer:
                 record_body = copy.deepcopy(body)
                 turn_type = _resolve_turn_type(x_turn_type, body.get("turn_type"), default="main")
                 injected_skills = owner._prepare_native_responses_body_inplace(body, turn_type=turn_type)
-                _raw_sid = x_session_id or codex_session_id or body.get("session_id") or ""
+                _raw_sid = x_session_id or codex_session_id or x_client_request_id or body.get("session_id") or ""
                 session_id = _raw_sid or await owner._resolve_tui_session(
                     body.get("model", owner._served_model),
                     len(body.get("input", []) if isinstance(body.get("input"), list) else []),
                 )
+                body["_skillclaw_codex_session_id"] = session_id
                 session_done = _resolve_session_done(x_session_done, body.get("session_done"))
                 if bool(body.get("stream", False)):
+                    stream = owner._stream_and_track_responses(
+                        body,
+                        record_body=record_body,
+                        session_id=session_id,
+                        turn_type=turn_type,
+                        injected_skills=injected_skills,
+                        session_done=session_done,
+                    )
+                    first_chunk = await anext(stream, None)
                     return StreamingResponse(
-                        owner._stream_and_track_responses(
-                            body,
-                            record_body=record_body,
-                            session_id=session_id,
-                            turn_type=turn_type,
-                            injected_skills=injected_skills,
-                            session_done=session_done,
-                        ),
+                        _prefetched_stream(first_chunk, stream),
                         media_type="text/event-stream",
                     )
                 response_payload = await owner._forward_to_llm_responses(body)
@@ -2550,6 +2611,7 @@ class SkillClawAPIServer:
         Supports providers:
           - ``"openai"`` (default) — any OpenAI-compatible ``/v1/chat/completions`` endpoint.
           - ``"openrouter"`` — OpenRouter gateway (OpenAI-compatible + routing extensions).
+          - ``"hermes-openai-codex"`` — Hermes-owned ChatGPT/Codex OAuth with runtime refresh.
           - ``"bedrock"`` — AWS Bedrock Converse API via :class:`BedrockChatClient`.
         """
         if self.config.llm_provider == "bedrock":
@@ -2560,18 +2622,31 @@ class SkillClawAPIServer:
         """Return whether /v1/responses should be forwarded as Responses API."""
         return str(getattr(self.config, "llm_api_mode", "chat") or "chat").lower() == "responses"
 
+    def _upstream_auth(self, *, force_refresh: bool = False) -> tuple[str, str, dict[str, str]]:
+        """Return the configured upstream endpoint, bearer, and transport headers."""
+        if self.config.llm_provider == "hermes-openai-codex":
+            try:
+                from .hermes_codex import resolve_upstream
+
+                return resolve_upstream(force_refresh=force_refresh)
+            except Exception as exc:
+                raise HTTPException(status_code=503, detail="Hermes Codex OAuth is unavailable") from exc
+        return self.config.llm_api_base.rstrip("/"), self.config.llm_api_key, {}
+
     def _prepare_responses_forward(
         self,
         body: dict[str, Any],
         *,
         stream: bool,
+        force_refresh: bool = False,
+        upstream_auth: tuple[str, str, dict[str, str]] | None = None,
     ) -> tuple[str, dict[str, Any], dict[str, str]]:
         """Build URL, body, and headers for native Responses forwarding.
 
         Native mode intentionally keeps Responses-only tools (custom, web_search,
         namespace, etc.) untouched instead of converting the request to chat.
         """
-        api_base = self.config.llm_api_base.rstrip("/")
+        api_base, api_key, headers = upstream_auth or self._upstream_auth(force_refresh=force_refresh)
         if not api_base:
             raise HTTPException(
                 status_code=503,
@@ -2581,10 +2656,15 @@ class SkillClawAPIServer:
         send_body = {k: v for k, v in body.items() if k not in _NON_STANDARD_BODY_KEYS}
         send_body["model"] = self.config.llm_model_id or body.get("model", "")
         send_body["stream"] = stream
-
-        headers: dict[str, str] = {}
-        if self.config.llm_api_key:
-            headers["Authorization"] = f"Bearer {self.config.llm_api_key}"
+        headers = dict(headers)
+        if self.config.llm_provider == "hermes-openai-codex":
+            send_body.pop("max_output_tokens", None)
+            cache_scope_id = str(body.get("_skillclaw_codex_session_id") or "").strip()
+            if cache_scope_id:
+                headers["session_id"] = cache_scope_id
+                headers["x-client-request-id"] = cache_scope_id
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         return f"{api_base}/responses", send_body, headers
 
     def _prepare_native_responses_body(self, body: dict[str, Any], *, turn_type: str) -> dict[str, Any]:
@@ -2693,10 +2773,21 @@ class SkillClawAPIServer:
         """Forward a Codex Responses payload to an upstream Responses API."""
         import httpx
 
-        url, send_body, headers = self._prepare_responses_forward(body, stream=False)
-
-        max_retries = 3
-        for attempt in range(max_retries):
+        max_transient_retries = 3
+        transient_attempt = 0
+        upstream_override = None
+        seen_tokens: set[str] = set()
+        auth_store_refresh_used = False
+        while True:
+            url, send_body, headers = self._prepare_responses_forward(
+                body,
+                stream=False,
+                upstream_auth=upstream_override,
+            )
+            upstream_override = None
+            failed_token = _bearer_token(headers)
+            if failed_token:
+                seen_tokens.add(failed_token)
             try:
                 async with httpx.AsyncClient(timeout=_llm_request_timeout_seconds()) as client:
                     resp = await client.post(
@@ -2707,31 +2798,50 @@ class SkillClawAPIServer:
                     resp.raise_for_status()
                     return resp.json()
             except httpx.HTTPStatusError as e:
-                response_text = e.response.text[:200]
-                if attempt < max_retries - 1:
-                    wait = min(2**attempt + random.uniform(0, 1), 10)
+                status_code = e.response.status_code
+                response_text = _safe_upstream_error_text(e.response, failed_token)
+                if self.config.llm_provider == "hermes-openai-codex" and status_code in {401, 429}:
+                    upstream_override, refresh_attempted = _recover_codex_auth(
+                        headers,
+                        status_code,
+                        seen_tokens,
+                        allow_auth_store_refresh=not auth_store_refresh_used,
+                    )
+                    auth_store_refresh_used |= refresh_attempted
+                    if upstream_override is not None:
+                        logger.warning("[Codex] recovered upstream credential after HTTP %d", status_code)
+                        continue
+                if self.config.llm_provider == "hermes-openai-codex" and status_code in {401, 429}:
+                    raise HTTPException(
+                        status_code=status_code,
+                        detail=f"Upstream Responses error: {status_code}",
+                    ) from e
+                if transient_attempt < max_transient_retries - 1:
+                    wait = min(2**transient_attempt + random.uniform(0, 1), 10)
                     logger.warning(
                         "[OpenClaw] upstream Responses error (attempt %d/%d), retrying in %.1fs: %s %s",
-                        attempt + 1,
-                        max_retries,
+                        transient_attempt + 1,
+                        max_transient_retries,
                         wait,
                         e.response.status_code,
                         response_text,
                     )
+                    transient_attempt += 1
                     await asyncio.sleep(wait)
                     continue
                 logger.error("[OpenClaw] upstream Responses error: %s %s", e.response.status_code, response_text)
                 raise HTTPException(status_code=502, detail=f"Upstream Responses error: {e}") from e
             except Exception as e:
-                if attempt < max_retries - 1:
-                    wait = min(2**attempt + random.uniform(0, 1), 10)
+                if transient_attempt < max_transient_retries - 1:
+                    wait = min(2**transient_attempt + random.uniform(0, 1), 10)
                     logger.warning(
                         "[OpenClaw] Responses forward failed (attempt %d/%d), retrying in %.1fs: %s",
-                        attempt + 1,
-                        max_retries,
+                        transient_attempt + 1,
+                        max_transient_retries,
                         wait,
                         e,
                     )
+                    transient_attempt += 1
                     await asyncio.sleep(wait)
                     continue
                 logger.error("[OpenClaw] Responses forward failed: %s", e, exc_info=True)
@@ -2853,27 +2963,59 @@ class SkillClawAPIServer:
         """Passthrough upstream Responses SSE without aggregating or rewriting events."""
         import httpx
 
-        url, send_body, headers = self._prepare_responses_forward(body, stream=True)
-        try:
-            async with httpx.AsyncClient(timeout=_llm_request_timeout_seconds()) as client:
-                async with client.stream("POST", url, json=send_body, headers=headers) as resp:
-                    resp.raise_for_status()
-                    async for chunk in resp.aiter_bytes():
-                        if chunk:
-                            yield chunk
-        except httpx.HTTPStatusError as e:
-            response_text = e.response.text[:200]
-            logger.error("[OpenClaw] upstream Responses stream error: %s %s", e.response.status_code, response_text)
-            raise HTTPException(status_code=502, detail=f"Upstream Responses stream error: {e}") from e
-        except Exception as e:
-            logger.error("[OpenClaw] Responses stream failed: %s", e, exc_info=True)
-            raise HTTPException(status_code=502, detail=f"Responses stream error: {e}") from e
+        upstream_override = None
+        seen_tokens: set[str] = set()
+        auth_store_refresh_used = False
+        while True:
+            url, send_body, headers = self._prepare_responses_forward(
+                body,
+                stream=True,
+                upstream_auth=upstream_override,
+            )
+            upstream_override = None
+            failed_token = _bearer_token(headers)
+            if failed_token:
+                seen_tokens.add(failed_token)
+            try:
+                async with httpx.AsyncClient(timeout=_llm_request_timeout_seconds()) as client:
+                    async with client.stream("POST", url, json=send_body, headers=headers) as resp:
+                        if getattr(resp, "status_code", 200) >= 400:
+                            await resp.aread()
+                        resp.raise_for_status()
+                        async for chunk in resp.aiter_bytes():
+                            if chunk:
+                                yield chunk
+                return
+            except httpx.HTTPStatusError as e:
+                status_code = e.response.status_code
+                response_text = _safe_upstream_error_text(e.response, failed_token)
+                if self.config.llm_provider == "hermes-openai-codex" and status_code in {401, 429}:
+                    upstream_override, refresh_attempted = _recover_codex_auth(
+                        headers,
+                        status_code,
+                        seen_tokens,
+                        allow_auth_store_refresh=not auth_store_refresh_used,
+                    )
+                    auth_store_refresh_used |= refresh_attempted
+                    if upstream_override is not None:
+                        logger.warning("[Codex] recovered streaming credential after HTTP %d", status_code)
+                        continue
+                logger.error("[OpenClaw] upstream Responses stream error: %s %s", status_code, response_text)
+                if self.config.llm_provider == "hermes-openai-codex" and status_code in {401, 429}:
+                    raise HTTPException(
+                        status_code=status_code,
+                        detail=f"Upstream Responses stream error: {status_code}",
+                    ) from e
+                raise HTTPException(status_code=502, detail=f"Upstream Responses stream error: {e}") from e
+            except Exception as e:
+                logger.error("[OpenClaw] Responses stream failed: %s", e, exc_info=True)
+                raise HTTPException(status_code=502, detail=f"Responses stream error: {e}") from e
 
     async def _forward_to_llm_openai(self, body: dict[str, Any]) -> dict[str, Any]:
         """Forward to an OpenAI-compatible API."""
         import httpx
 
-        api_base = self.config.llm_api_base.rstrip("/")
+        api_base, api_key, headers = self._upstream_auth()
         if not api_base:
             raise HTTPException(
                 status_code=503,
@@ -2885,9 +3027,9 @@ class SkillClawAPIServer:
         send_body["model"] = self.config.llm_model_id or body.get("model", "")
         send_body["stream"] = False
 
-        headers: dict[str, str] = {}
-        if self.config.llm_api_key:
-            headers["Authorization"] = f"Bearer {self.config.llm_api_key}"
+        headers = dict(headers)
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
 
         # OpenRouter-specific headers and body extensions
         if self.config.llm_provider == "openrouter":

--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -52,6 +52,7 @@ _NON_STANDARD_BODY_KEYS = {
 }
 _PROTOCOL_ANTHROPIC_MESSAGES = "anthropic_messages"
 _PROTOCOL_RESPONSES_COMPAT = "responses_compat"
+_MAX_CODEX_AUTH_RECOVERIES = 8
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -80,12 +81,17 @@ def _recover_codex_auth(
     seen_tokens: set[str],
     *,
     allow_auth_store_refresh: bool,
+    refreshed_credential_ids: set[str],
 ) -> tuple[tuple[str, str, dict[str, str]] | None, bool]:
     """Return an unseen pooled/refreshed credential and whether auth refresh ran."""
     from .hermes_codex import recover_upstream, resolve_upstream
 
     failed_token = _bearer_token(headers)
-    candidate = recover_upstream(failed_token, status_code=status_code)
+    candidate = recover_upstream(
+        failed_token,
+        status_code=status_code,
+        refreshed_credential_ids=refreshed_credential_ids,
+    )
     if candidate is not None and candidate[1] not in seen_tokens:
         return candidate, False
     if status_code == 401 and allow_auth_store_refresh:
@@ -1489,8 +1495,11 @@ class SkillClawAPIServer:
         prm_scorer: Optional[PRMScorer] = None,
         last_request_tracker=None,
     ):
-        if config.llm_provider == "hermes-openai-codex" and not config.proxy_api_key:
-            raise ValueError("hermes-openai-codex requires proxy.api_key")
+        if config.llm_provider == "hermes-openai-codex":
+            if not config.proxy_api_key:
+                raise ValueError("hermes-openai-codex requires proxy.api_key")
+            if not _is_loopback_host(config.proxy_host):
+                raise ValueError("hermes-openai-codex requires a loopback proxy.host")
         self.config = config
         self._sampling_client = sampling_client
         self.skill_manager = skill_manager
@@ -2782,6 +2791,8 @@ class SkillClawAPIServer:
         upstream_override = None
         seen_tokens: set[str] = set()
         auth_store_refresh_used = False
+        auth_recovery_attempts = 0
+        refreshed_credential_ids: set[str] = set()
         while True:
             url, send_body, headers = self._prepare_responses_forward(
                 body,
@@ -2863,12 +2874,18 @@ class SkillClawAPIServer:
             except httpx.HTTPStatusError as e:
                 status_code = e.response.status_code
                 response_text = _safe_upstream_error_text(e.response, failed_token)
-                if self.config.llm_provider == "hermes-openai-codex" and status_code in {401, 429}:
+                if (
+                    self.config.llm_provider == "hermes-openai-codex"
+                    and status_code in {401, 429}
+                    and auth_recovery_attempts < _MAX_CODEX_AUTH_RECOVERIES
+                ):
+                    auth_recovery_attempts += 1
                     upstream_override, refresh_attempted = _recover_codex_auth(
                         headers,
                         status_code,
                         seen_tokens,
                         allow_auth_store_refresh=not auth_store_refresh_used,
+                        refreshed_credential_ids=refreshed_credential_ids,
                     )
                     auth_store_refresh_used |= refresh_attempted
                     if upstream_override is not None:
@@ -2920,8 +2937,9 @@ class SkillClawAPIServer:
         injected_skills: list[str],
         session_done: bool,
     ):
-        """Wrap _stream_llm_responses: passthrough SSE + parse response.completed inline."""
-        tracked = False
+        """Frame upstream SSE, record terminal events, and make truncation explicit."""
+        terminal_seen = False
+        emitted = False
         buf = ""
         output_items: dict[int, dict[str, Any]] = {}
         output_text_parts: dict[tuple[int, int], str] = {}
@@ -2979,7 +2997,7 @@ class SkillClawAPIServer:
                     text = str(part.get("text") or output_text_parts.get((output_index, content_index), ""))
                     output_text_parts[(output_index, content_index)] = text
                     apply_output_text(output_index, content_index, text)
-            elif event_type == "response.completed":
+            elif event_type in {"response.completed", "response.incomplete", "response.failed"}:
                 response_payload = data.get("response") if isinstance(data.get("response"), dict) else dict(data)
                 if output_items and not response_payload.get("output"):
                     response_payload = {
@@ -2989,38 +3007,59 @@ class SkillClawAPIServer:
                 return response_payload
             return None
 
-        async for chunk in self._stream_llm_responses(body):
-            if not tracked:
-                try:
-                    text = chunk.decode("utf-8", errors="ignore") if isinstance(chunk, bytes) else chunk
-                    buf += text
-                    while "\n" in buf:
-                        line, buf = buf.split("\n", 1)
-                        stripped = line.strip()
-                        if not stripped.startswith("data: "):
-                            continue
-                        raw = stripped[6:]
-                        if raw == "[DONE]":
-                            continue
+        def record_terminal(response_payload: dict[str, Any]) -> None:
+            self._record_responses_turn(
+                session_id,
+                record_body or body,
+                response_payload,
+                turn_type=turn_type,
+                injected_skills=injected_skills,
+                session_done=session_done,
+            )
+
+        try:
+            async for chunk in self._stream_llm_responses(body):
+                text = chunk.decode("utf-8", errors="ignore") if isinstance(chunk, bytes) else str(chunk)
+                buf += text.replace("\r\n", "\n")
+                while "\n\n" in buf:
+                    frame, buf = buf.split("\n\n", 1)
+                    raw_values = [line[6:] for line in frame.splitlines() if line.startswith("data: ")]
+                    if raw_values == ["[DONE]"]:
+                        continue
+                    for raw in raw_values:
                         try:
                             data = json.loads(raw)
                         except Exception:
                             continue
                         response_payload = parse_responses_stream_event(data) if isinstance(data, dict) else None
-                        if response_payload is not None:
-                            self._record_responses_turn(
-                                session_id,
-                                record_body or body,
-                                response_payload,
-                                turn_type=turn_type,
-                                injected_skills=injected_skills,
-                                session_done=session_done,
-                            )
-                            tracked = True
-                            break
-                except Exception:
-                    pass
-            yield chunk
+                        if response_payload is not None and not terminal_seen:
+                            record_terminal(response_payload)
+                            terminal_seen = True
+                    yield (frame + "\n\n").encode()
+                    emitted = True
+        except Exception:
+            if not emitted:
+                raise
+            logger.warning("[Codex] upstream Responses stream failed after downstream streaming began")
+
+        if terminal_seen:
+            yield b"data: [DONE]\n\n"
+            return
+        if not emitted:
+            raise HTTPException(status_code=502, detail="Upstream Responses stream ended without a terminal event")
+
+        failed_response = {
+            "status": "failed",
+            "output": [item for _, item in sorted(output_items.items())],
+            "error": {
+                "code": "upstream_stream_ended",
+                "message": "Upstream Responses stream ended without a terminal event",
+            },
+        }
+        record_terminal(failed_response)
+        failed_event = {"type": "response.failed", "response": failed_response}
+        yield ("data: " + json.dumps(failed_event, separators=(",", ":")) + "\n\n").encode()
+        yield b"data: [DONE]\n\n"
 
     async def _stream_llm_responses(self, body: dict[str, Any]):
         """Passthrough upstream Responses SSE without aggregating or rewriting events."""
@@ -3029,6 +3068,8 @@ class SkillClawAPIServer:
         upstream_override = None
         seen_tokens: set[str] = set()
         auth_store_refresh_used = False
+        auth_recovery_attempts = 0
+        refreshed_credential_ids: set[str] = set()
         while True:
             url, send_body, headers = self._prepare_responses_forward(
                 body,
@@ -3052,12 +3093,18 @@ class SkillClawAPIServer:
             except httpx.HTTPStatusError as e:
                 status_code = e.response.status_code
                 response_text = _safe_upstream_error_text(e.response, failed_token)
-                if self.config.llm_provider == "hermes-openai-codex" and status_code in {401, 429}:
+                if (
+                    self.config.llm_provider == "hermes-openai-codex"
+                    and status_code in {401, 429}
+                    and auth_recovery_attempts < _MAX_CODEX_AUTH_RECOVERIES
+                ):
+                    auth_recovery_attempts += 1
                     upstream_override, refresh_attempted = _recover_codex_auth(
                         headers,
                         status_code,
                         seen_tokens,
                         allow_auth_store_refresh=not auth_store_refresh_used,
+                        refreshed_credential_ids=refreshed_credential_ids,
                     )
                     auth_store_refresh_used |= refresh_attempted
                     if upstream_override is not None:

--- a/skillclaw/claw_adapter.py
+++ b/skillclaw/claw_adapter.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _LEGACY_SKILLCLAW_SKILLS_DIR = Path.home() / ".skillclaw" / "skills"
-_HERMES_HOME = Path.home() / ".hermes"
+_HERMES_HOME = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
 _HERMES_SKILLS_DIR = _HERMES_HOME / "skills"
 _HERMES_BACKUP_DIR = Path.home() / ".skillclaw" / "backups" / "hermes"
 _CODEX_HOME = Path.home() / ".codex"
@@ -470,25 +470,57 @@ def _write_json_mapping_atomic(path: Path, data: dict, label: str) -> None:
 
 
 def _configure_hermes(cfg: "SkillClawConfig") -> None:
-    """Auto-configure Hermes to route model traffic through SkillClaw."""
+    """Route Hermes through SkillClaw, preserving the upstream protocol mode."""
     config_path = _HERMES_HOME / "config.yaml"
-    model_id = cfg.served_model_name or cfg.llm_model_id or "skillclaw-model"
     api_key = cfg.proxy_api_key or "skillclaw"
     base_url = f"http://127.0.0.1:{cfg.proxy_port}/v1"
+    uses_hermes_codex_oauth = cfg.llm_provider == "hermes-openai-codex"
     _prepare_hermes_skills_dir(cfg)
 
     data = _load_yaml_mapping(config_path, "Hermes")
+    providers = data.get("custom_providers")
+    if not isinstance(providers, list):
+        providers = []
+    providers = [entry for entry in providers if not (isinstance(entry, dict) and entry.get("name") == "skillclaw")]
+
+    named_providers = data.get("providers")
+    if not isinstance(named_providers, dict):
+        named_providers = {}
+    else:
+        named_providers = dict(named_providers)
+    named_providers.pop("skillclaw-codex", None)
+
     model = data.get("model")
     if not isinstance(model, dict):
         model = {"default": model} if isinstance(model, str) and model.strip() else {}
 
-    model["provider"] = "custom"
-    model["base_url"] = base_url
-    model["default"] = model_id
-    model["api_key"] = api_key
-    # Clear stale provider-specific mode so Hermes auto-detects from the proxy URL.
-    model["api_mode"] = ""
+    if uses_hermes_codex_oauth:
+        upstream_model = cfg.llm_model_id or cfg.served_model_name or "skillclaw-model"
+        named_providers["skillclaw-codex"] = {
+            "name": "SkillClaw Codex OAuth proxy",
+            "api": base_url,
+            "api_key": api_key,
+            "default_model": upstream_model,
+            "transport": "codex_responses",
+        }
+        model["provider"] = "custom:skillclaw-codex"
+        model["default"] = upstream_model
+        model.pop("base_url", None)
+        model.pop("api_key", None)
+        model.pop("api_mode", None)
+    else:
+        model_id = cfg.served_model_name or cfg.llm_model_id or "skillclaw-model"
+        model["provider"] = "custom"
+        model["base_url"] = base_url
+        model["default"] = model_id
+        model["api_key"] = api_key
+        model["api_mode"] = ""
 
+    data["custom_providers"] = providers
+    if named_providers:
+        data["providers"] = named_providers
+    else:
+        data.pop("providers", None)
     data["model"] = model
     _backup_hermes_config_if_changed(config_path, _yaml_mapping_to_text(data))
     _write_yaml_mapping_atomic(config_path, data, "Hermes")
@@ -497,7 +529,12 @@ def _configure_hermes(cfg: "SkillClawConfig") -> None:
 def inspect_hermes_config(cfg: "SkillClawConfig") -> dict[str, object]:
     """Return a diagnostic snapshot of the local Hermes integration state."""
     config_path = _HERMES_HOME / "config.yaml"
-    expected_model = cfg.served_model_name or cfg.llm_model_id or "skillclaw-model"
+    uses_hermes_codex_oauth = cfg.llm_provider == "hermes-openai-codex"
+    expected_model = (
+        cfg.llm_model_id or cfg.served_model_name or "skillclaw-model"
+        if uses_hermes_codex_oauth
+        else cfg.served_model_name or cfg.llm_model_id or "skillclaw-model"
+    )
     expected_base_url = f"http://127.0.0.1:{cfg.proxy_port}/v1"
     expected_api_key = cfg.proxy_api_key or "skillclaw"
     expected_skills_dir = Path(str(getattr(cfg, "skills_dir", "") or _HERMES_SKILLS_DIR)).expanduser()
@@ -506,19 +543,36 @@ def inspect_hermes_config(cfg: "SkillClawConfig") -> dict[str, object]:
     model = data.get("model") if isinstance(data, dict) else {}
     if not isinstance(model, dict):
         model = {"default": model} if isinstance(model, str) and model else {}
-
     configured_provider = str(model.get("provider", "") or "")
-    configured_base_url = str(model.get("base_url", "") or "")
     configured_default = str(model.get("default", "") or "")
-    configured_api_key = str(model.get("api_key", "") or "")
+    if uses_hermes_codex_oauth:
+        named_providers = data.get("providers")
+        named_provider = named_providers.get("skillclaw-codex", {}) if isinstance(named_providers, dict) else {}
+        if not isinstance(named_provider, dict):
+            named_provider = {}
+        configured_base_url = str(named_provider.get("api") or named_provider.get("base_url") or "")
+        configured_api_key = str(named_provider.get("api_key", "") or "")
+        configured_api_mode = str(named_provider.get("transport") or named_provider.get("api_mode") or "")
+        proxy_match = (
+            configured_provider == "custom:skillclaw-codex"
+            and configured_base_url == expected_base_url
+            and configured_default == expected_model
+            and configured_api_key == expected_api_key
+            and configured_api_mode == "codex_responses"
+        )
+    else:
+        configured_base_url = str(model.get("base_url", "") or "")
+        configured_api_key = str(model.get("api_key", "") or "")
+        configured_api_mode = str(model.get("api_mode", "") or "")
+        proxy_match = (
+            configured_provider == "custom"
+            and configured_base_url == expected_base_url
+            and configured_default == expected_model
+            and configured_api_key == expected_api_key
+            and not configured_api_mode
+        )
 
     backup_path = _latest_hermes_backup_path()
-    proxy_match = (
-        configured_provider == "custom"
-        and configured_base_url == expected_base_url
-        and configured_default == expected_model
-        and configured_api_key == expected_api_key
-    )
     legacy_present = _LEGACY_SKILLCLAW_SKILLS_DIR.is_dir()
     uses_default_skills_dir = expected_skills_dir == _HERMES_SKILLS_DIR
     issues: list[str] = []
@@ -528,6 +582,19 @@ def inspect_hermes_config(cfg: "SkillClawConfig") -> dict[str, object]:
         " available, with proxy-side heuristics as the fallback.",
     ]
     next_steps: list[str] = []
+
+    if uses_hermes_codex_oauth:
+        from .hermes_codex import HermesInstallationError, resolve_upstream
+
+        try:
+            resolve_upstream()
+            notes.append("Hermes Codex OAuth credential resolution succeeded.")
+        except HermesInstallationError:
+            issues.append("Hermes runtime modules are unavailable to SkillClaw.")
+            next_steps.append("Install Hermes for this user, then retry `skillclaw doctor hermes`.")
+        except Exception:
+            issues.append("Hermes Codex OAuth credentials are unavailable.")
+            next_steps.append("Run `hermes auth add openai-codex`, then retry `skillclaw doctor hermes`.")
 
     if not config_path.exists():
         issues.append("Hermes config is missing: ~/.hermes/config.yaml")

--- a/skillclaw/claw_adapter.py
+++ b/skillclaw/claw_adapter.py
@@ -23,6 +23,7 @@ it in ``_ADAPTERS``.
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import logging
 import os
@@ -32,6 +33,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
+from urllib.parse import urlsplit
 
 import yaml
 
@@ -426,12 +428,42 @@ def _prepare_external_skills_dir(target_dir: Path, label: str) -> None:
         )
 
 
+def _is_loopback_skillclaw_url(value: object) -> bool:
+    try:
+        parsed = urlsplit(str(value or ""))
+    except ValueError:
+        return False
+    return parsed.scheme == "http" and parsed.hostname in {"127.0.0.1", "localhost", "::1"} and parsed.path == "/v1"
+
+
+def _is_managed_legacy_hermes_provider(entry: object) -> bool:
+    return (
+        isinstance(entry, dict)
+        and entry.get("name") == "skillclaw"
+        and _is_loopback_skillclaw_url(entry.get("base_url") or entry.get("api"))
+    )
+
+
+def _is_managed_codex_hermes_provider(entry: object) -> bool:
+    return (
+        isinstance(entry, dict)
+        and entry.get("name") == "SkillClaw Codex OAuth proxy"
+        and entry.get("transport") == "codex_responses"
+        and _is_loopback_skillclaw_url(entry.get("api") or entry.get("base_url"))
+    )
+
+
+def _hermes_profile_backup_dir() -> Path:
+    profile_key = hashlib.sha256(str(_HERMES_HOME.resolve()).encode()).hexdigest()[:12]
+    return _HERMES_BACKUP_DIR / profile_key
+
+
 def _backup_hermes_config_if_changed(config_path: Path, new_text: str) -> Path | None:
     """Save the current Hermes config before overwriting it, if it changed."""
     return _backup_text_file_if_changed(
         config_path,
         new_text,
-        backup_dir=_HERMES_BACKUP_DIR,
+        backup_dir=_hermes_profile_backup_dir(),
         backup_stem="config",
         backup_suffix="yaml",
         label="Hermes config",
@@ -439,7 +471,12 @@ def _backup_hermes_config_if_changed(config_path: Path, new_text: str) -> Path |
 
 
 def _latest_hermes_backup_path() -> Path | None:
-    return _latest_backup_path(_HERMES_BACKUP_DIR, "config", "yaml")
+    profile_backup = _latest_backup_path(_hermes_profile_backup_dir(), "config", "yaml")
+    if profile_backup is not None:
+        return profile_backup
+    if _HERMES_HOME == Path.home() / ".hermes":
+        return _latest_backup_path(_HERMES_BACKUP_DIR, "config", "yaml")
+    return None
 
 
 def _write_json_mapping_atomic(path: Path, data: dict, label: str) -> None:
@@ -481,14 +518,22 @@ def _configure_hermes(cfg: "SkillClawConfig") -> None:
     providers = data.get("custom_providers")
     if not isinstance(providers, list):
         providers = []
-    providers = [entry for entry in providers if not (isinstance(entry, dict) and entry.get("name") == "skillclaw")]
+    providers = [entry for entry in providers if not _is_managed_legacy_hermes_provider(entry)]
 
     named_providers = data.get("providers")
     if not isinstance(named_providers, dict):
         named_providers = {}
     else:
         named_providers = dict(named_providers)
-    named_providers.pop("skillclaw-codex", None)
+    existing_codex_provider = named_providers.get("skillclaw-codex")
+    if (
+        uses_hermes_codex_oauth
+        and existing_codex_provider
+        and not _is_managed_codex_hermes_provider(existing_codex_provider)
+    ):
+        raise ValueError("Hermes provider name 'skillclaw-codex' is already user-owned")
+    if _is_managed_codex_hermes_provider(existing_codex_provider):
+        named_providers.pop("skillclaw-codex", None)
 
     model = data.get("model")
     if not isinstance(model, dict):
@@ -597,10 +642,10 @@ def inspect_hermes_config(cfg: "SkillClawConfig") -> dict[str, object]:
             next_steps.append("Run `hermes auth add openai-codex`, then retry `skillclaw doctor hermes`.")
 
     if not config_path.exists():
-        issues.append("Hermes config is missing: ~/.hermes/config.yaml")
+        issues.append(f"Hermes config is missing: {config_path}")
     if not proxy_match:
         issues.append("Hermes model routing is not pointing at the local SkillClaw proxy.")
-        next_steps.append("Start SkillClaw once so it can rewrite ~/.hermes/config.yaml.")
+        next_steps.append(f"Start SkillClaw once so it can rewrite {config_path}.")
     if not expected_skills_dir.is_dir():
         issues.append(f"Hermes skills directory is missing: {expected_skills_dir}")
         next_steps.append(f"Create or prepare the Hermes skills directory: {expected_skills_dir}")
@@ -639,7 +684,7 @@ def inspect_hermes_config(cfg: "SkillClawConfig") -> dict[str, object]:
 
 
 def restore_hermes_config(backup_path: Path | None = None) -> dict[str, str]:
-    """Restore ~/.hermes/config.yaml from the latest or a specified backup."""
+    """Restore the active HERMES_HOME config from the latest or a specified backup."""
     source = Path(backup_path).expanduser() if backup_path is not None else _latest_hermes_backup_path()
     if source is None or not source.exists():
         raise FileNotFoundError("No Hermes backup found")

--- a/skillclaw/cli.py
+++ b/skillclaw/cli.py
@@ -473,7 +473,7 @@ def restore():
     help="Restore from a specific backup file instead of the latest Hermes backup.",
 )
 def restore_hermes(backup_path: str | None):
-    """Restore ~/.hermes/config.yaml from a saved backup."""
+    """Restore the active HERMES_HOME config from a saved backup."""
     from .claw_adapter import restore_hermes_config
 
     try:

--- a/skillclaw/config_store.py
+++ b/skillclaw/config_store.py
@@ -7,6 +7,7 @@ Reads/writes ~/.skillclaw/config.yaml and bridges to SkillClawConfig.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -15,7 +16,7 @@ from .config import SkillClawConfig
 CONFIG_DIR = Path.home() / ".skillclaw"
 CONFIG_FILE = CONFIG_DIR / "config.yaml"
 _DEFAULT_SKILLS_DIR = CONFIG_DIR / "skills"
-_DEFAULT_HERMES_SKILLS_DIR = Path.home() / ".hermes" / "skills"
+_LEGACY_DEFAULT_HERMES_SKILLS_DIR = Path.home() / ".hermes" / "skills"
 _DEFAULT_CODEX_SKILLS_DIR = Path.home() / ".codex" / "skills"
 _DEFAULT_CLAUDE_SKILLS_DIR = Path.home() / ".claude" / "skills"
 _DEFAULT_OPENCODE_SKILLS_DIR = Path.home() / ".config" / "opencode" / "skills"
@@ -194,7 +195,8 @@ def default_skills_dir_for_claw(claw_type: str) -> Path:
     """Return the default local skills directory for the selected agent."""
     normalized = str(claw_type or "").strip().lower()
     if normalized == "hermes":
-        return _DEFAULT_HERMES_SKILLS_DIR
+        hermes_home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
+        return hermes_home / "skills"
     if normalized == "codex":
         return _DEFAULT_CODEX_SKILLS_DIR
     if normalized == "claude":
@@ -224,6 +226,8 @@ def resolve_skills_dir(skills_dir: Any, *, claw_type: str) -> str:
     if raw:
         expanded = Path(raw).expanduser()
         if normalized_claw in {"hermes", "codex", "claude", "opencode"} and expanded == generic_default:
+            return str(default_skills_dir_for_claw(normalized_claw))
+        if normalized_claw == "hermes" and expanded == _LEGACY_DEFAULT_HERMES_SKILLS_DIR:
             return str(default_skills_dir_for_claw(normalized_claw))
         return str(expanded)
 

--- a/skillclaw/hermes_codex.py
+++ b/skillclaw/hermes_codex.py
@@ -8,10 +8,36 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 from typing import Callable
+from urllib.parse import urlsplit
 
 
 class HermesInstallationError(RuntimeError):
     """Hermes runtime modules cannot be imported from the active installation."""
+
+
+def _validated_codex_base_url(value: str) -> str:
+    """Keep Hermes OAuth bearers on the canonical ChatGPT Codex endpoint."""
+    normalized = str(value or "").strip().rstrip("/")
+    parsed = urlsplit(normalized)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "chatgpt.com"
+        or parsed.port not in {None, 443}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path.rstrip("/") != "/backend-api/codex"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise RuntimeError("Hermes Codex OAuth endpoint is not trusted")
+    return normalized
+
+
+def _pool_credential_id(pool, token: str) -> str:
+    for entry in getattr(pool, "_entries", ()):
+        if str(getattr(entry, "runtime_api_key", "") or "") == token:
+            return str(getattr(entry, "id", "") or "")
+    return ""
 
 
 def _runtime_imports() -> tuple[Callable, Callable]:
@@ -74,11 +100,21 @@ def recover_upstream(
     failed_token: str,
     *,
     status_code: int,
+    refreshed_credential_ids: set[str] | None = None,
 ) -> tuple[str, str, dict[str, str]] | None:
     """Refresh/rotate the failed pooled credential and return a retry credential."""
     try:
         pool, default_base_url = _pool_runtime()
-        next_entry = pool.try_refresh_matching(api_key_hint=failed_token) if status_code == 401 else None
+        refreshed_credential_ids = refreshed_credential_ids if refreshed_credential_ids is not None else set()
+        failed_credential_id = _pool_credential_id(pool, failed_token)
+        can_refresh = status_code == 401 and (
+            not failed_credential_id or failed_credential_id not in refreshed_credential_ids
+        )
+        next_entry = pool.try_refresh_matching(api_key_hint=failed_token) if can_refresh else None
+        if next_entry is not None:
+            refreshed_id = str(getattr(next_entry, "id", "") or failed_credential_id)
+            if refreshed_id:
+                refreshed_credential_ids.add(refreshed_id)
         if next_entry is None:
             next_entry = pool.mark_exhausted_and_rotate(
                 status_code=status_code,
@@ -88,7 +124,7 @@ def recover_upstream(
         if next_entry is None or not next_entry.runtime_api_key:
             return None
         token = next_entry.runtime_api_key
-        base_url = str(next_entry.base_url or next_entry.inference_base_url or default_base_url).rstrip("/")
+        base_url = _validated_codex_base_url(next_entry.base_url or next_entry.inference_base_url or default_base_url)
         _, header_builder = _resolver()
         return base_url, token, header_builder(token)
     except Exception:
@@ -119,4 +155,4 @@ def resolve_upstream(*, force_refresh: bool = False) -> tuple[str, str, dict[str
     if not base_url or not api_key:
         raise RuntimeError("Hermes has no usable Codex OAuth credential")
     base_url, api_key = _select_pool_credential(base_url, api_key)
-    return base_url, api_key, header_builder(api_key)
+    return _validated_codex_base_url(base_url), api_key, header_builder(api_key)

--- a/skillclaw/hermes_codex.py
+++ b/skillclaw/hermes_codex.py
@@ -1,0 +1,122 @@
+"""Resolve Hermes-managed Codex OAuth credentials without taking ownership of them."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import Callable
+
+
+class HermesInstallationError(RuntimeError):
+    """Hermes runtime modules cannot be imported from the active installation."""
+
+
+def _runtime_imports() -> tuple[Callable, Callable]:
+    from agent.auxiliary_client import _codex_cloudflare_headers
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    return resolve_codex_runtime_credentials, _codex_cloudflare_headers
+
+
+def _candidate_sources() -> list[Path]:
+    hermes_home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
+    candidates: list[Path] = []
+    legacy_home = os.environ.get("SKILLCLAW_HERMES_HOME")
+    if legacy_home:
+        candidates.append(Path(legacy_home).expanduser() / "hermes-agent")
+    candidates.extend(
+        [
+            hermes_home / "hermes-agent",
+            Path.home() / ".hermes" / "hermes-agent",
+        ]
+    )
+    executable = shutil.which("hermes")
+    if executable:
+        resolved = Path(executable).resolve()
+        candidates.extend(parent for parent in resolved.parents if (parent / "hermes_cli" / "auth.py").is_file())
+    return list(dict.fromkeys(path for path in candidates if path is not None))
+
+
+@lru_cache(maxsize=1)
+def _resolver() -> tuple[Callable, Callable]:
+    try:
+        return _runtime_imports()
+    except ImportError:
+        pass
+
+    checked: list[str] = []
+    for source in _candidate_sources():
+        checked.append(str(source))
+        if not (source / "hermes_cli" / "auth.py").is_file():
+            continue
+        if str(source) not in sys.path:
+            sys.path.insert(0, str(source))
+        try:
+            return _runtime_imports()
+        except ImportError:
+            continue
+
+    raise HermesInstallationError("Hermes runtime modules were not importable; checked: " + ", ".join(checked))
+
+
+def _pool_runtime():
+    _resolver()  # Ensure Hermes source/package is importable before pool imports.
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import DEFAULT_CODEX_BASE_URL
+
+    return load_pool("openai-codex"), DEFAULT_CODEX_BASE_URL
+
+
+def recover_upstream(
+    failed_token: str,
+    *,
+    status_code: int,
+) -> tuple[str, str, dict[str, str]] | None:
+    """Refresh/rotate the failed pooled credential and return a retry credential."""
+    try:
+        pool, default_base_url = _pool_runtime()
+        next_entry = pool.try_refresh_matching(api_key_hint=failed_token) if status_code == 401 else None
+        if next_entry is None:
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=status_code,
+                error_context={"message": f"HTTP {status_code}"},
+                api_key_hint=failed_token,
+            )
+        if next_entry is None or not next_entry.runtime_api_key:
+            return None
+        token = next_entry.runtime_api_key
+        base_url = str(next_entry.base_url or next_entry.inference_base_url or default_base_url).rstrip("/")
+        _, header_builder = _resolver()
+        return base_url, token, header_builder(token)
+    except Exception:
+        return None
+
+
+def _select_pool_credential(base_url: str, token: str) -> tuple[str, str]:
+    """Prefer Hermes's active pooled account while retaining auth-store fallback."""
+    try:
+        pool, _ = _pool_runtime()
+    except Exception:
+        return base_url, token
+    if not pool.has_credentials():
+        return base_url, token
+    entry = pool.select()
+    if entry is None or not entry.runtime_api_key:
+        raise RuntimeError("Hermes Codex credential pool has no available credential")
+    selected_base = entry.base_url or entry.inference_base_url or base_url
+    return str(selected_base).rstrip("/"), entry.runtime_api_key
+
+
+def resolve_upstream(*, force_refresh: bool = False) -> tuple[str, str, dict[str, str]]:
+    """Return the Codex endpoint, transient bearer, and required transport headers."""
+    credential_resolver, header_builder = _resolver()
+    credentials = credential_resolver(force_refresh=force_refresh)
+    base_url = str(credentials.get("base_url") or "").rstrip("/")
+    api_key = str(credentials.get("api_key") or "")
+    if not base_url or not api_key:
+        raise RuntimeError("Hermes has no usable Codex OAuth credential")
+    base_url, api_key = _select_pool_credential(base_url, api_key)
+    return base_url, api_key, header_builder(api_key)

--- a/skillclaw/setup_wizard.py
+++ b/skillclaw/setup_wizard.py
@@ -5,6 +5,7 @@ Interactive first-time setup wizard for SkillClaw.
 
 from __future__ import annotations
 
+import secrets
 from pathlib import Path
 
 from .claw_adapter import CLAW_TYPES
@@ -38,6 +39,10 @@ _PROVIDER_PRESETS = {
     "bedrock": {
         "api_base": "",
         "model_id": "us.anthropic.claude-sonnet-4-6",
+    },
+    "hermes-openai-codex": {
+        "api_base": "",
+        "model_id": "gpt-5.6-sol",
     },
     "custom": {
         "api_base": "",
@@ -91,6 +96,17 @@ def _prompt_choice(msg: str, choices: list[str], default: str = "") -> str:
         print(f"  Invalid choice. Pick one of: {choices}")
 
 
+def _validate_hermes_codex_oauth() -> None:
+    from .hermes_codex import HermesInstallationError, resolve_upstream
+
+    try:
+        resolve_upstream()
+    except HermesInstallationError as exc:
+        raise RuntimeError("Hermes runtime is unavailable. Install Hermes for this user and retry.") from exc
+    except Exception as exc:
+        raise RuntimeError("Hermes Codex OAuth is unavailable. Run `hermes auth add openai-codex` and retry.") from exc
+
+
 def _infer_existing_sharing_backend(current_sharing: dict) -> str:
     backend = str(current_sharing.get("backend", "") or "").strip().lower()
     if backend:
@@ -131,10 +147,22 @@ class SetupWizard:
         current_provider = current_llm.get("provider", "custom")
         provider = _prompt_choice(
             "LLM provider",
-            ["kimi", "qwen", "openai", "minimax", "novita", "openrouter", "bedrock", "custom"],
+            [
+                "kimi",
+                "qwen",
+                "openai",
+                "minimax",
+                "novita",
+                "openrouter",
+                "bedrock",
+                "hermes-openai-codex",
+                "custom",
+            ],
             default=current_provider,
         )
         preset = _PROVIDER_PRESETS[provider]
+        if provider == "hermes-openai-codex" and claw_type != "hermes":
+            raise ValueError("hermes-openai-codex is only supported with the Hermes CLI adapter")
         openrouter_config: dict = existing.get("openrouter", {})
         if provider == "bedrock":
             api_base = ""
@@ -147,6 +175,16 @@ class SetupWizard:
                 "AWS region",
                 default=current_llm.get("bedrock_region", "us-east-1"),
             )
+        elif provider == "hermes-openai-codex":
+            _validate_hermes_codex_oauth()
+            print("Uses Hermes-managed ChatGPT/Codex OAuth; no API key is stored in SkillClaw.")
+            api_base = ""
+            api_key = ""
+            model_id = _prompt(
+                "Codex model ID",
+                default=current_llm.get("model_id") or preset["model_id"],
+            )
+            bedrock_region = ""
         else:
             bedrock_region = ""
             api_base = _prompt(
@@ -223,9 +261,12 @@ class SetupWizard:
         # ---- PRM ----
         print("\n--- PRM (Quality Scoring) ---")
         current_prm = existing.get("prm", {})
+        default_prm_enabled = current_prm.get("enabled", True)
+        if provider == "hermes-openai-codex" and not current_prm.get("api_key") and not current_prm.get("url"):
+            default_prm_enabled = False
         prm_enabled = _prompt_bool(
             "Enable PRM response quality scoring",
-            default=current_prm.get("enabled", True),
+            default=default_prm_enabled,
         )
         prm_config: dict = {"enabled": False}
         if prm_enabled:
@@ -359,10 +400,19 @@ class SetupWizard:
         # ---- Write config ----
         proxy_config = dict(current_proxy)
         proxy_config["port"] = proxy_port
-        proxy_config.setdefault("host", "0.0.0.0")
+        if provider == "hermes-openai-codex":
+            proxy_config["host"] = "127.0.0.1"
+            proxy_config["api_key"] = str(current_proxy.get("api_key") or secrets.token_urlsafe(32))
+        else:
+            proxy_config.setdefault("host", "0.0.0.0")
         proxy_config["served_model_name"] = served_model_name or "skillclaw-model"
         default_api_mode = default_llm_api_mode_for_claw(claw_type)
-        llm_api_mode = str(current_llm.get("api_mode", default_api_mode) or default_api_mode)
+        if provider == "hermes-openai-codex":
+            llm_api_mode = "responses"
+        elif provider == current_llm.get("provider"):
+            llm_api_mode = str(current_llm.get("api_mode", default_api_mode) or default_api_mode)
+        else:
+            llm_api_mode = default_api_mode
         data = {
             "claw_type": claw_type,
             "llm": {

--- a/tests/test_hermes_codex.py
+++ b/tests/test_hermes_codex.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -73,11 +74,11 @@ def test_hermes_codex_responses_preserve_native_transport(monkeypatch):
             "max_output_tokens": 4096,
             "_skillclaw_codex_session_id": "session-test",
         },
-        stream=True,
+        stream=False,
     )
 
     assert url == "https://chatgpt.com/backend-api/codex/responses"
-    assert body == {"model": "gpt-5.6-sol", "stream": True}
+    assert body == {"model": "gpt-5.6-sol", "stream": True, "store": False}
     assert headers == {
         "Authorization": "Bearer runtime-token",
         "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
@@ -390,6 +391,19 @@ async def test_nonstreaming_401_forces_one_oauth_refresh(monkeypatch):
             self.status_code = status_code
             self.text = "unauthorized" if status_code == 401 else "ok"
 
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aread(self):
+            return self.text.encode()
+
+        async def aiter_text(self):
+            if self.status_code == 200:
+                yield f"data: {json.dumps({'type': 'response.completed', 'response': self.json()})}\n\n"
+
         def raise_for_status(self):
             if self.status_code == 401:
                 request = httpx.Request("POST", "https://upstream.test/responses")
@@ -410,6 +424,10 @@ async def test_nonstreaming_401_forces_one_oauth_refresh(monkeypatch):
             return False
 
         async def post(self, url, json, headers):
+            status = 401 if headers["Authorization"] == "Bearer stale-token" else 200
+            return FakeResponse(status)
+
+        def stream(self, method, url, json, headers):
             status = 401 if headers["Authorization"] == "Bearer stale-token" else 200
             return FakeResponse(status)
 
@@ -435,6 +453,19 @@ async def test_nonstreaming_429_exhausts_pool_until_success(monkeypatch):
             self.status_code = 429 if token != "healthy-token" else 200
             self.text = "quota exhausted"
 
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aread(self):
+            return self.text.encode()
+
+        async def aiter_text(self):
+            if self.status_code == 200:
+                yield f"data: {json.dumps({'type': 'response.completed', 'response': self.json()})}\n\n"
+
         def raise_for_status(self):
             if self.status_code == 429:
                 request = httpx.Request("POST", "https://upstream.test/responses")
@@ -459,6 +490,11 @@ async def test_nonstreaming_429_exhausts_pool_until_success(monkeypatch):
             sent_tokens.append(token)
             return FakeResponse(token)
 
+        def stream(self, method, url, json, headers):
+            token = headers["Authorization"].removeprefix("Bearer ")
+            sent_tokens.append(token)
+            return FakeResponse(token)
+
     def rotate(token, *, status_code):
         rotations.append((token, status_code))
         next_token = {"old-token": "next-token", "next-token": "healthy-token"}.get(token)
@@ -476,6 +512,72 @@ async def test_nonstreaming_429_exhausts_pool_until_success(monkeypatch):
     assert await server._forward_to_llm_responses({"model": "gpt-5.6-sol"}) == {"id": "resp-healthy"}
     assert sent_tokens == ["old-token", "next-token", "healthy-token"]
     assert rotations == [("old-token", 429), ("next-token", 429)]
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_codex_sse_assembles_output_and_preserves_incomplete_status(monkeypatch):
+    events = [
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {"type": "message", "role": "assistant", "status": "in_progress", "content": []},
+        },
+        {"type": "response.output_text.delta", "output_index": 0, "content_index": 0, "delta": "hello "},
+        {"type": "response.output_text.delta", "output_index": 0, "content_index": 0, "delta": "world"},
+        {
+            "type": "response.incomplete",
+            "response": {"id": "resp-incomplete", "status": "incomplete", "output": []},
+        },
+    ]
+
+    class FakeResponse:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aiter_text(self):
+            for event in events:
+                yield f"data: {json.dumps(event)}\n\n"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, json, headers):
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        "skillclaw.hermes_codex.resolve_upstream",
+        lambda **_: ("https://upstream.test", "runtime-token", {}),
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(llm_provider="hermes-openai-codex", llm_api_mode="responses")
+
+    response = await server._forward_to_llm_responses({"model": "gpt-5.6-sol"})
+
+    assert response["status"] == "incomplete"
+    assert response["output"] == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "in_progress",
+            "content": [{"type": "output_text", "text": "hello world", "annotations": []}],
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_hermes_codex.py
+++ b/tests/test_hermes_codex.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 from skillclaw import claw_adapter, hermes_codex
 from skillclaw.api_server import SkillClawAPIServer
 from skillclaw.config import SkillClawConfig
+from skillclaw.config_store import resolve_skills_dir
 
 
 def _oauth_result(*, force_refresh: bool = False):
@@ -49,6 +50,18 @@ def test_resolve_upstream_reuses_hermes_credentials_and_headers(monkeypatch):
         "runtime-token",
         {"originator": "codex_cli_rs", "token-seen": "runtime-token"},
     )
+
+
+def test_resolve_upstream_rejects_non_chatgpt_oauth_endpoint(monkeypatch):
+    monkeypatch.setattr(hermes_codex, "_select_pool_credential", lambda base_url, token: (base_url, token))
+    monkeypatch.setattr(
+        hermes_codex,
+        "_resolver",
+        lambda: (lambda **_: {"base_url": "https://evil.test/codex", "api_key": "secret"}, lambda _: {}),
+    )
+
+    with pytest.raises(RuntimeError, match="not trusted"):
+        hermes_codex.resolve_upstream()
 
 
 def test_hermes_codex_upstream_uses_runtime_oauth(monkeypatch):
@@ -96,6 +109,17 @@ def test_oauth_proxy_rejects_unauthenticated_non_loopback_bind():
                 llm_provider="hermes-openai-codex",
                 proxy_host="0.0.0.0",
                 proxy_api_key="",
+            )
+        )
+
+
+def test_oauth_proxy_rejects_authenticated_non_loopback_bind():
+    with pytest.raises(ValueError, match="loopback proxy.host"):
+        SkillClawAPIServer(
+            SkillClawConfig(
+                llm_provider="hermes-openai-codex",
+                proxy_host="0.0.0.0",
+                proxy_api_key="local-proxy-key",
             )
         )
 
@@ -237,6 +261,64 @@ def test_configure_hermes_generic_provider_keeps_generic_proxy_mode(monkeypatch,
     assert claw_adapter.inspect_hermes_config(cfg)["proxy_match"] is True
 
 
+def test_configure_hermes_preserves_user_owned_reserved_provider_names(monkeypatch, tmp_path: Path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    user_legacy = {"name": "skillclaw", "base_url": "https://user-provider.test/v1"}
+    user_named = {"name": "User provider", "api": "https://user-provider.test/v1"}
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {"provider": "openai", "default": "model"},
+                "custom_providers": [user_legacy],
+                "providers": {"skillclaw-codex": user_named},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(claw_adapter, "_HERMES_HOME", hermes_home)
+    monkeypatch.setattr(claw_adapter, "_HERMES_SKILLS_DIR", hermes_home / "skills")
+    monkeypatch.setattr(claw_adapter, "_HERMES_BACKUP_DIR", tmp_path / "backups")
+    monkeypatch.setattr(claw_adapter, "_LEGACY_SKILLCLAW_SKILLS_DIR", tmp_path / "legacy")
+
+    claw_adapter._configure_hermes(
+        SkillClawConfig(
+            claw_type="hermes",
+            llm_provider="openrouter",
+            llm_model_id="upstream-model",
+            proxy_api_key="local-key",
+        )
+    )
+
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert data["custom_providers"] == [user_legacy]
+    assert data["providers"]["skillclaw-codex"] == user_named
+
+
+def test_configure_hermes_codex_refuses_user_owned_provider_collision(monkeypatch, tmp_path: Path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"providers": {"skillclaw-codex": {"name": "User provider", "api": "https://user.test"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(claw_adapter, "_HERMES_HOME", hermes_home)
+    monkeypatch.setattr(claw_adapter, "_HERMES_SKILLS_DIR", hermes_home / "skills")
+    monkeypatch.setattr(claw_adapter, "_LEGACY_SKILLCLAW_SKILLS_DIR", tmp_path / "legacy")
+
+    with pytest.raises(ValueError, match="already user-owned"):
+        claw_adapter._configure_hermes(
+            SkillClawConfig(
+                claw_type="hermes",
+                llm_provider="hermes-openai-codex",
+                llm_model_id="gpt-5.6-sol",
+                proxy_api_key="local-key",
+            )
+        )
+
+
 def test_doctor_reports_missing_hermes_oauth(monkeypatch, tmp_path: Path):
     cfg = SkillClawConfig(
         claw_type="hermes",
@@ -297,10 +379,36 @@ def test_adapter_uses_hermes_home_environment_in_fresh_process(tmp_path: Path):
     assert result.stdout.splitlines() == [str(hermes_home), str(hermes_home / "skills")]
 
 
+def test_config_store_migrates_legacy_hermes_skills_default(monkeypatch, tmp_path: Path):
+    hermes_home = tmp_path / "profile-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    assert resolve_skills_dir(str(Path.home() / ".hermes" / "skills"), claw_type="hermes") == str(
+        hermes_home / "skills"
+    )
+
+
+def test_hermes_backups_are_isolated_by_profile(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(claw_adapter, "_HERMES_BACKUP_DIR", tmp_path / "backups")
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    for profile, original in ((profile_a, "A\n"), (profile_b, "B\n")):
+        profile.mkdir()
+        (profile / "config.yaml").write_text(original, encoding="utf-8")
+        monkeypatch.setattr(claw_adapter, "_HERMES_HOME", profile)
+        claw_adapter._backup_hermes_config_if_changed(profile / "config.yaml", "changed\n")
+
+    monkeypatch.setattr(claw_adapter, "_HERMES_HOME", profile_a)
+    (profile_a / "config.yaml").write_text("changed\n", encoding="utf-8")
+    claw_adapter.restore_hermes_config()
+
+    assert (profile_a / "config.yaml").read_text(encoding="utf-8") == "A\n"
+
+
 def test_recover_upstream_refreshes_matching_pool_entry(monkeypatch):
     refreshed = SimpleNamespace(
         runtime_api_key="fresh-token",
-        base_url="https://fresh.test/codex",
+        base_url="https://chatgpt.com/backend-api/codex",
         inference_base_url=None,
     )
 
@@ -312,7 +420,11 @@ def test_recover_upstream_refreshes_matching_pool_entry(monkeypatch):
         def mark_exhausted_and_rotate(self, **kwargs):
             raise AssertionError("successful refresh must not rotate")
 
-    monkeypatch.setattr(hermes_codex, "_pool_runtime", lambda: (FakePool(), "https://default.test"))
+    monkeypatch.setattr(
+        hermes_codex,
+        "_pool_runtime",
+        lambda: (FakePool(), "https://chatgpt.com/backend-api/codex"),
+    )
     monkeypatch.setattr(
         hermes_codex,
         "_resolver",
@@ -320,10 +432,49 @@ def test_recover_upstream_refreshes_matching_pool_entry(monkeypatch):
     )
 
     assert hermes_codex.recover_upstream("stale-token", status_code=401) == (
-        "https://fresh.test/codex",
+        "https://chatgpt.com/backend-api/codex",
         "fresh-token",
         {"account-token": "fresh-token"},
     )
+
+
+def test_recover_upstream_refreshes_each_pool_entry_once(monkeypatch):
+    entry = SimpleNamespace(
+        id="credential-1",
+        runtime_api_key="stale-token",
+        base_url="https://chatgpt.com/backend-api/codex",
+        inference_base_url=None,
+    )
+    refreshes = []
+    rotations = []
+
+    class FakePool:
+        _entries = [entry]
+
+        def try_refresh_matching(self, *, api_key_hint):
+            refreshes.append(api_key_hint)
+            entry.runtime_api_key = "fresh-token"
+            return entry
+
+        def mark_exhausted_and_rotate(self, **kwargs):
+            rotations.append(kwargs["api_key_hint"])
+            return None
+
+    monkeypatch.setattr(
+        hermes_codex,
+        "_pool_runtime",
+        lambda: (FakePool(), "https://chatgpt.com/backend-api/codex"),
+    )
+    monkeypatch.setattr(hermes_codex, "_resolver", lambda: (lambda **_: {}, lambda _: {}))
+    refreshed_ids: set[str] = set()
+
+    assert (
+        hermes_codex.recover_upstream("stale-token", status_code=401, refreshed_credential_ids=refreshed_ids)
+        is not None
+    )
+    assert hermes_codex.recover_upstream("fresh-token", status_code=401, refreshed_credential_ids=refreshed_ids) is None
+    assert refreshes == ["stale-token"]
+    assert rotations == ["fresh-token"]
 
 
 def test_recover_upstream_never_persists_upstream_error_body(monkeypatch):
@@ -495,7 +646,7 @@ async def test_nonstreaming_429_exhausts_pool_until_success(monkeypatch):
             sent_tokens.append(token)
             return FakeResponse(token)
 
-    def rotate(token, *, status_code):
+    def rotate(token, *, status_code, **_):
         rotations.append((token, status_code))
         next_token = {"old-token": "next-token", "next-token": "healthy-token"}.get(token)
         return ("https://upstream.test", next_token, {}) if next_token else None
@@ -512,6 +663,64 @@ async def test_nonstreaming_429_exhausts_pool_until_success(monkeypatch):
     assert await server._forward_to_llm_responses({"model": "gpt-5.6-sol"}) == {"id": "resp-healthy"}
     assert sent_tokens == ["old-token", "next-token", "healthy-token"]
     assert rotations == [("old-token", 429), ("next-token", 429)]
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_codex_auth_recovery_is_bounded(monkeypatch):
+    attempts = []
+    recoveries = []
+
+    class FakeResponse:
+        status_code = 401
+        text = "unauthorized"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aread(self):
+            return b"unauthorized"
+
+        def raise_for_status(self):
+            request = httpx.Request("POST", "https://upstream.test/responses")
+            response = httpx.Response(401, request=request, text=self.text)
+            raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, json, headers):
+            attempts.append(headers["Authorization"])
+            return FakeResponse()
+
+    def recover(token, *, status_code, **_):
+        recoveries.append((token, status_code))
+        return "https://upstream.test", f"token-{len(recoveries)}", {}
+
+    monkeypatch.setattr(
+        "skillclaw.hermes_codex.resolve_upstream",
+        lambda **_: ("https://upstream.test", "token-0", {}),
+    )
+    monkeypatch.setattr("skillclaw.hermes_codex.recover_upstream", recover)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(llm_provider="hermes-openai-codex", llm_api_mode="responses")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await server._forward_to_llm_responses({"model": "gpt-5.6-sol"})
+
+    assert exc_info.value.status_code == 401
+    assert len(recoveries) == 8
+    assert len(attempts) == 9
 
 
 @pytest.mark.asyncio
@@ -701,7 +910,7 @@ async def test_streaming_429_reads_error_and_exhausts_pool_until_success(monkeyp
                 )
             return FakeStreamContext(response)
 
-    def rotate(token, *, status_code):
+    def rotate(token, *, status_code, **_):
         rotations.append((token, status_code))
         next_token = {"old-token": "next-token", "next-token": "healthy-token"}.get(token)
         if next_token is None:

--- a/tests/test_hermes_codex.py
+++ b/tests/test_hermes_codex.py
@@ -1,0 +1,624 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import httpx
+import pytest
+import yaml
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from skillclaw import claw_adapter, hermes_codex
+from skillclaw.api_server import SkillClawAPIServer
+from skillclaw.config import SkillClawConfig
+
+
+def _oauth_result(*, force_refresh: bool = False):
+    token = "fresh-runtime-token" if force_refresh else "runtime-token"
+    return (
+        "https://chatgpt.com/backend-api/codex",
+        token,
+        {
+            "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+            "originator": "codex_cli_rs",
+            "ChatGPT-Account-ID": "acct-test",
+        },
+    )
+
+
+def test_resolve_upstream_reuses_hermes_credentials_and_headers(monkeypatch):
+    monkeypatch.setattr(hermes_codex, "_select_pool_credential", lambda base_url, token: (base_url, token))
+    monkeypatch.setattr(
+        hermes_codex,
+        "_resolver",
+        lambda: (
+            lambda **_: {
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "runtime-token",
+            },
+            lambda token: {"originator": "codex_cli_rs", "token-seen": token},
+        ),
+    )
+
+    assert hermes_codex.resolve_upstream() == (
+        "https://chatgpt.com/backend-api/codex",
+        "runtime-token",
+        {"originator": "codex_cli_rs", "token-seen": "runtime-token"},
+    )
+
+
+def test_hermes_codex_upstream_uses_runtime_oauth(monkeypatch):
+    monkeypatch.setattr("skillclaw.hermes_codex.resolve_upstream", _oauth_result)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(llm_provider="hermes-openai-codex")
+
+    assert server._upstream_auth() == _oauth_result()
+
+
+def test_hermes_codex_responses_preserve_native_transport(monkeypatch):
+    monkeypatch.setattr("skillclaw.hermes_codex.resolve_upstream", _oauth_result)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(
+        llm_provider="hermes-openai-codex",
+        llm_model_id="gpt-5.6-sol",
+        llm_api_mode="responses",
+    )
+
+    url, body, headers = server._prepare_responses_forward(
+        {
+            "model": "skillclaw-model",
+            "max_output_tokens": 4096,
+            "_skillclaw_codex_session_id": "session-test",
+        },
+        stream=True,
+    )
+
+    assert url == "https://chatgpt.com/backend-api/codex/responses"
+    assert body == {"model": "gpt-5.6-sol", "stream": True}
+    assert headers == {
+        "Authorization": "Bearer runtime-token",
+        "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+        "originator": "codex_cli_rs",
+        "ChatGPT-Account-ID": "acct-test",
+        "session_id": "session-test",
+        "x-client-request-id": "session-test",
+    }
+
+
+def test_oauth_proxy_rejects_unauthenticated_non_loopback_bind():
+    with pytest.raises(ValueError, match="requires proxy.api_key"):
+        SkillClawAPIServer(
+            SkillClawConfig(
+                llm_provider="hermes-openai-codex",
+                proxy_host="0.0.0.0",
+                proxy_api_key="",
+            )
+        )
+
+
+def test_oauth_proxy_rejects_unauthenticated_loopback_bind():
+    with pytest.raises(ValueError, match="requires proxy.api_key"):
+        SkillClawAPIServer(
+            SkillClawConfig(
+                llm_provider="hermes-openai-codex",
+                proxy_host="127.0.0.1",
+                proxy_api_key="",
+            )
+        )
+
+
+def test_oauth_proxy_requires_its_local_bearer():
+    server = SkillClawAPIServer(
+        SkillClawConfig(
+            llm_provider="hermes-openai-codex",
+            proxy_host="127.0.0.1",
+            proxy_api_key="local-proxy-key",
+        )
+    )
+
+    with TestClient(server.app) as client:
+        assert client.get("/v1/models").status_code == 401
+        assert (
+            client.get(
+                "/v1/models",
+                headers={"Authorization": "Bearer local-proxy-key"},
+            ).status_code
+            == 200
+        )
+
+
+def test_streaming_auth_failure_is_returned_before_downstream_200(monkeypatch):
+    server = SkillClawAPIServer(
+        SkillClawConfig(
+            llm_provider="hermes-openai-codex",
+            llm_api_mode="responses",
+            proxy_host="127.0.0.1",
+            proxy_api_key="local-proxy-key",
+        )
+    )
+
+    async def fail_before_first_chunk(*args, **kwargs):
+        if False:
+            yield b""
+        raise HTTPException(status_code=429, detail="Upstream Responses stream error: 429")
+
+    monkeypatch.setattr(server, "_stream_and_track_responses", fail_before_first_chunk)
+
+    with TestClient(server.app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/v1/responses",
+            headers={
+                "Authorization": "Bearer local-proxy-key",
+                "x-session-id": "stream-error-test",
+            },
+            json={"model": "gpt-5.6-sol", "input": [], "stream": True},
+        )
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Upstream Responses stream error: 429"
+
+
+def _configure_hermes(monkeypatch, tmp_path: Path, cfg: SkillClawConfig) -> Path:
+    hermes_home = tmp_path / ".hermes"
+    config_path = hermes_home / "config.yaml"
+    hermes_home.mkdir()
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {"provider": "openai-codex", "default": "gpt-5.6-sol"},
+                "custom_providers": [{"name": "keep-me", "base_url": "http://keep.test/v1"}],
+                "providers": {"keep-named": {"api": "http://named.test/v1"}},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(claw_adapter, "_HERMES_HOME", hermes_home)
+    monkeypatch.setattr(claw_adapter, "_HERMES_SKILLS_DIR", hermes_home / "skills")
+    monkeypatch.setattr(claw_adapter, "_HERMES_BACKUP_DIR", tmp_path / "backups")
+    monkeypatch.setattr(claw_adapter, "_LEGACY_SKILLCLAW_SKILLS_DIR", tmp_path / "legacy")
+    monkeypatch.setattr("skillclaw.hermes_codex.resolve_upstream", _oauth_result)
+    claw_adapter._configure_hermes(cfg)
+    return config_path
+
+
+def test_configure_hermes_codex_oauth_uses_named_native_transport(monkeypatch, tmp_path: Path):
+    cfg = SkillClawConfig(
+        claw_type="hermes",
+        llm_provider="hermes-openai-codex",
+        llm_model_id="gpt-5.6-sol",
+        proxy_port=31000,
+        proxy_api_key="skillclaw-key",
+    )
+    config_path = _configure_hermes(monkeypatch, tmp_path, cfg)
+
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert data["model"] == {
+        "provider": "custom:skillclaw-codex",
+        "default": "gpt-5.6-sol",
+    }
+    assert data["providers"]["skillclaw-codex"] == {
+        "name": "SkillClaw Codex OAuth proxy",
+        "api": "http://127.0.0.1:31000/v1",
+        "api_key": "skillclaw-key",
+        "default_model": "gpt-5.6-sol",
+        "transport": "codex_responses",
+    }
+    assert data["providers"]["keep-named"] == {"api": "http://named.test/v1"}
+    assert {p["name"] for p in data["custom_providers"]} == {"keep-me"}
+    assert claw_adapter.inspect_hermes_config(cfg)["proxy_match"] is True
+
+
+def test_configure_hermes_generic_provider_keeps_generic_proxy_mode(monkeypatch, tmp_path: Path):
+    cfg = SkillClawConfig(
+        claw_type="hermes",
+        llm_provider="openrouter",
+        llm_model_id="upstream-model",
+        served_model_name="skillclaw-model",
+        proxy_port=31000,
+        proxy_api_key="skillclaw-key",
+    )
+    config_path = _configure_hermes(monkeypatch, tmp_path, cfg)
+
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert data["model"] == {
+        "provider": "custom",
+        "base_url": "http://127.0.0.1:31000/v1",
+        "default": "skillclaw-model",
+        "api_key": "skillclaw-key",
+        "api_mode": "",
+    }
+    assert data["providers"] == {"keep-named": {"api": "http://named.test/v1"}}
+    assert {p["name"] for p in data["custom_providers"]} == {"keep-me"}
+    assert claw_adapter.inspect_hermes_config(cfg)["proxy_match"] is True
+
+
+def test_doctor_reports_missing_hermes_oauth(monkeypatch, tmp_path: Path):
+    cfg = SkillClawConfig(
+        claw_type="hermes",
+        llm_provider="hermes-openai-codex",
+        llm_model_id="gpt-5.6-sol",
+        proxy_api_key="skillclaw-key",
+    )
+    _configure_hermes(monkeypatch, tmp_path, cfg)
+
+    def unavailable():
+        raise RuntimeError("missing login")
+
+    monkeypatch.setattr("skillclaw.hermes_codex.resolve_upstream", unavailable)
+    report = claw_adapter.inspect_hermes_config(cfg)
+
+    assert report["status"] == "warning"
+    assert "Hermes Codex OAuth credentials are unavailable." in cast(list[str], report["issues"])
+    assert any("hermes auth add openai-codex" in step for step in cast(list[str], report["next_steps"]))
+
+
+def test_resolver_discovers_source_from_hermes_executable(monkeypatch, tmp_path: Path):
+    source = tmp_path / "hermes-agent"
+    executable = source / "venv" / "bin" / "hermes"
+    executable.parent.mkdir(parents=True)
+    executable.touch()
+    (source / "hermes_cli").mkdir()
+    (source / "hermes_cli" / "auth.py").touch()
+    monkeypatch.setattr(hermes_codex.shutil, "which", lambda _: str(executable))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "state-only-home"))
+
+    assert source in hermes_codex._candidate_sources()
+
+
+def test_resolver_preserves_legacy_hermes_home_override(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("SKILLCLAW_HERMES_HOME", str(tmp_path / "custom-home"))
+
+    assert hermes_codex._candidate_sources()[0] == tmp_path / "custom-home" / "hermes-agent"
+
+
+def test_adapter_uses_hermes_home_environment_in_fresh_process(tmp_path: Path):
+    hermes_home = tmp_path / "profile-home"
+    env = {**os.environ, "HERMES_HOME": str(hermes_home)}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from skillclaw.claw_adapter import _HERMES_HOME, _HERMES_SKILLS_DIR; "
+                "print(_HERMES_HOME); print(_HERMES_SKILLS_DIR)"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.stdout.splitlines() == [str(hermes_home), str(hermes_home / "skills")]
+
+
+def test_recover_upstream_refreshes_matching_pool_entry(monkeypatch):
+    refreshed = SimpleNamespace(
+        runtime_api_key="fresh-token",
+        base_url="https://fresh.test/codex",
+        inference_base_url=None,
+    )
+
+    class FakePool:
+        def try_refresh_matching(self, *, api_key_hint):
+            assert api_key_hint == "stale-token"
+            return refreshed
+
+        def mark_exhausted_and_rotate(self, **kwargs):
+            raise AssertionError("successful refresh must not rotate")
+
+    monkeypatch.setattr(hermes_codex, "_pool_runtime", lambda: (FakePool(), "https://default.test"))
+    monkeypatch.setattr(
+        hermes_codex,
+        "_resolver",
+        lambda: (lambda **_: {}, lambda token: {"account-token": token}),
+    )
+
+    assert hermes_codex.recover_upstream("stale-token", status_code=401) == (
+        "https://fresh.test/codex",
+        "fresh-token",
+        {"account-token": "fresh-token"},
+    )
+
+
+def test_recover_upstream_never_persists_upstream_error_body(monkeypatch):
+    captured = {}
+
+    class FakePool:
+        def try_refresh_matching(self, *, api_key_hint):
+            return None
+
+        def mark_exhausted_and_rotate(self, **kwargs):
+            captured.update(kwargs)
+            return None
+
+    monkeypatch.setattr(hermes_codex, "_pool_runtime", lambda: (FakePool(), "https://default.test"))
+
+    assert hermes_codex.recover_upstream("secret-token", status_code=429) is None
+    assert captured["error_context"] == {"message": "HTTP 429"}
+    assert "secret-token" not in str(captured["error_context"])
+
+
+def test_resolver_does_not_reuse_auth_store_token_when_pool_is_exhausted(monkeypatch):
+    class ExhaustedPool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return None
+
+    monkeypatch.setattr(hermes_codex, "_pool_runtime", lambda: (ExhaustedPool(), "https://default.test"))
+
+    with pytest.raises(RuntimeError, match="no available credential"):
+        hermes_codex._select_pool_credential("https://upstream.test", "known-exhausted-token")
+
+
+def test_doctor_distinguishes_missing_hermes_runtime(monkeypatch, tmp_path: Path):
+    cfg = SkillClawConfig(
+        claw_type="hermes",
+        llm_provider="hermes-openai-codex",
+        llm_model_id="gpt-5.6-sol",
+        proxy_api_key="skillclaw-key",
+    )
+    _configure_hermes(monkeypatch, tmp_path, cfg)
+
+    def missing_runtime():
+        raise hermes_codex.HermesInstallationError("not installed")
+
+    monkeypatch.setattr("skillclaw.hermes_codex.resolve_upstream", missing_runtime)
+    report = claw_adapter.inspect_hermes_config(cfg)
+
+    assert "Hermes runtime modules are unavailable to SkillClaw." in cast(list[str], report["issues"])
+    assert not any("hermes auth add" in step for step in cast(list[str], report["next_steps"]))
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_401_forces_one_oauth_refresh(monkeypatch):
+    refreshes = []
+
+    def resolve(*, force_refresh=False):
+        refreshes.append(force_refresh)
+        token = "fresh-token" if force_refresh else "stale-token"
+        return "https://upstream.test", token, {"originator": "codex_cli_rs"}
+
+    class FakeResponse:
+        def __init__(self, status_code):
+            self.status_code = status_code
+            self.text = "unauthorized" if status_code == 401 else "ok"
+
+        def raise_for_status(self):
+            if self.status_code == 401:
+                request = httpx.Request("POST", "https://upstream.test/responses")
+                response = httpx.Response(401, request=request, text=self.text)
+                raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+        def json(self):
+            return {"id": "resp-refreshed"}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json, headers):
+            status = 401 if headers["Authorization"] == "Bearer stale-token" else 200
+            return FakeResponse(status)
+
+    monkeypatch.setattr("skillclaw.hermes_codex.resolve_upstream", resolve)
+    monkeypatch.setattr("skillclaw.hermes_codex.recover_upstream", lambda *args, **kwargs: None)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(llm_provider="hermes-openai-codex", llm_api_mode="responses")
+
+    result = await server._forward_to_llm_responses({"model": "gpt-5.6-sol"})
+
+    assert result == {"id": "resp-refreshed"}
+    assert refreshes == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_429_exhausts_pool_until_success(monkeypatch):
+    sent_tokens = []
+    rotations = []
+
+    class FakeResponse:
+        def __init__(self, token):
+            self.status_code = 429 if token != "healthy-token" else 200
+            self.text = "quota exhausted"
+
+        def raise_for_status(self):
+            if self.status_code == 429:
+                request = httpx.Request("POST", "https://upstream.test/responses")
+                response = httpx.Response(429, request=request, text=self.text)
+                raise httpx.HTTPStatusError("rate limited", request=request, response=response)
+
+        def json(self):
+            return {"id": "resp-healthy"}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json, headers):
+            token = headers["Authorization"].removeprefix("Bearer ")
+            sent_tokens.append(token)
+            return FakeResponse(token)
+
+    def rotate(token, *, status_code):
+        rotations.append((token, status_code))
+        next_token = {"old-token": "next-token", "next-token": "healthy-token"}.get(token)
+        return ("https://upstream.test", next_token, {}) if next_token else None
+
+    monkeypatch.setattr(
+        "skillclaw.hermes_codex.resolve_upstream",
+        lambda **_: ("https://upstream.test", "old-token", {}),
+    )
+    monkeypatch.setattr("skillclaw.hermes_codex.recover_upstream", rotate)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(llm_provider="hermes-openai-codex", llm_api_mode="responses")
+
+    assert await server._forward_to_llm_responses({"model": "gpt-5.6-sol"}) == {"id": "resp-healthy"}
+    assert sent_tokens == ["old-token", "next-token", "healthy-token"]
+    assert rotations == [("old-token", 429), ("next-token", 429)]
+
+
+@pytest.mark.asyncio
+async def test_generic_nonstreaming_429_keeps_existing_transient_retries(monkeypatch):
+    attempts = []
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json, headers):
+            attempts.append(url)
+            request = httpx.Request("POST", url)
+            return httpx.Response(429, request=request, text="rate limited")
+
+    async def no_sleep(_):
+        pass
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr("skillclaw.api_server.asyncio.sleep", no_sleep)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(
+        llm_provider="openai",
+        llm_api_base="https://upstream.test/v1",
+        llm_api_key="static-key",
+        llm_api_mode="responses",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await server._forward_to_llm_responses({"model": "generic-model"})
+
+    assert exc_info.value.status_code == 502
+    assert len(attempts) == 3
+
+
+@pytest.mark.asyncio
+async def test_generic_streaming_401_keeps_existing_502_mapping(monkeypatch):
+    class FakeStreamContext:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self.response
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, json, headers):
+            request = httpx.Request("POST", url)
+            response = httpx.Response(401, request=request, stream=httpx.ByteStream(b"unauthorized"))
+            return FakeStreamContext(response)
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(
+        llm_provider="openai",
+        llm_api_base="https://upstream.test/v1",
+        llm_api_key="static-key",
+        llm_api_mode="responses",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _ = [chunk async for chunk in server._stream_llm_responses({"model": "generic-model"})]
+
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_streaming_429_reads_error_and_exhausts_pool_until_success(monkeypatch, caplog):
+    sent_tokens = []
+    rotations = []
+
+    class FakeStreamContext:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self.response
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, json, headers):
+            token = headers["Authorization"].removeprefix("Bearer ")
+            sent_tokens.append(token)
+            request = httpx.Request("POST", "https://upstream.test/responses")
+            if token in {"old-token", "next-token"}:
+                body = f"quota exhausted; reflected bearer={token}".encode()
+                response = httpx.Response(429, request=request, stream=httpx.ByteStream(body))
+            else:
+                response = httpx.Response(
+                    200,
+                    request=request,
+                    stream=httpx.ByteStream(b'data: {"type":"response.completed"}\n\n'),
+                )
+            return FakeStreamContext(response)
+
+    def rotate(token, *, status_code):
+        rotations.append((token, status_code))
+        next_token = {"old-token": "next-token", "next-token": "healthy-token"}.get(token)
+        if next_token is None:
+            return None
+        return "https://upstream.test", next_token, {"originator": "codex_cli_rs"}
+
+    monkeypatch.setattr(
+        "skillclaw.hermes_codex.resolve_upstream",
+        lambda **_: ("https://upstream.test", "old-token", {"originator": "codex_cli_rs"}),
+    )
+    monkeypatch.setattr("skillclaw.hermes_codex.recover_upstream", rotate)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(llm_provider="hermes-openai-codex", llm_api_mode="responses")
+
+    chunks = [chunk async for chunk in server._stream_llm_responses({"model": "gpt-5.6-sol"})]
+
+    assert chunks == [b'data: {"type":"response.completed"}\n\n']
+    assert sent_tokens == ["old-token", "next-token", "healthy-token"]
+    assert rotations == [("old-token", 429), ("next-token", 429)]
+    assert "old-token" not in caplog.text
+    assert "next-token" not in caplog.text

--- a/tests/test_responses_native.py
+++ b/tests/test_responses_native.py
@@ -416,7 +416,8 @@ async def test_stream_and_track_responses_records_before_completed_chunk_is_cons
     )
     first = await stream.__anext__()
     second = await stream.__anext__()
-    assert first + second == ("data: " + json.dumps(completed_event) + "\n\n").encode()
+    assert first == ("data: " + json.dumps(completed_event) + "\n\n").encode()
+    assert second == b"data: [DONE]\n\n"
     assert recorded == {
         "session_id": "codex-session-1",
         "request_body": {"model": "skillclaw-model", "instructions": "original instructions", "stream": True},
@@ -509,6 +510,71 @@ async def test_stream_and_track_responses_records_output_from_stream_events_when
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "terminal_type, status", [("response.incomplete", "incomplete"), ("response.failed", "failed")]
+)
+async def test_stream_and_track_responses_records_all_terminal_events(terminal_type, status):
+    server = object.__new__(SkillClawAPIServer)
+    recorded = []
+    event = {"type": terminal_type, "response": {"status": status, "output": []}}
+
+    async def fake_stream(_body):
+        yield ("data: " + json.dumps(event) + "\n\n").encode()
+        yield b"data: [DONE]\n\n"
+
+    def fake_record(_session_id, _request_body, response_payload, **_):
+        recorded.append(response_payload["status"])
+
+    server._stream_llm_responses = fake_stream
+    server._record_responses_turn = fake_record
+
+    chunks = [
+        chunk
+        async for chunk in server._stream_and_track_responses(
+            {"stream": True},
+            session_id="session",
+            turn_type="main",
+            injected_skills=[],
+            session_done=False,
+        )
+    ]
+
+    assert recorded == [status]
+    assert chunks[-1] == b"data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_stream_and_track_responses_emits_failure_for_truncated_stream():
+    server = object.__new__(SkillClawAPIServer)
+    recorded = []
+
+    async def fake_stream(_body):
+        yield b'data: {"type":"response.created"}\n\n'
+        yield b"data: [DONE]\n\n"
+
+    def fake_record(_session_id, _request_body, response_payload, **_):
+        recorded.append(response_payload)
+
+    server._stream_llm_responses = fake_stream
+    server._record_responses_turn = fake_record
+
+    chunks = [
+        chunk
+        async for chunk in server._stream_and_track_responses(
+            {"stream": True},
+            session_id="session",
+            turn_type="main",
+            injected_skills=[],
+            session_done=False,
+        )
+    ]
+
+    assert json.loads(chunks[-2].decode().removeprefix("data: "))["type"] == "response.failed"
+    assert recorded[0]["error"]["code"] == "upstream_stream_ended"
+    assert chunks[-1] == b"data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
 async def test_responses_endpoint_passthroughs_native_stream():
     server = SkillClawAPIServer(
         SkillClawConfig(
@@ -522,6 +588,7 @@ async def test_responses_endpoint_passthroughs_native_stream():
 
     async def fake_stream(body):
         yield b'data: {"type":"response.created","upstream":true}\n\n'
+        yield b'data: {"type":"response.completed","response":{"status":"completed","output":[]}}\n\n'
         yield b"data: [DONE]\n\n"
 
     server._stream_llm_responses = fake_stream
@@ -536,7 +603,11 @@ async def test_responses_endpoint_passthroughs_native_stream():
         await client.aclose()
 
     assert response.status_code == 200
-    assert response.text == 'data: {"type":"response.created","upstream":true}\n\ndata: [DONE]\n\n'
+    assert response.text == (
+        'data: {"type":"response.created","upstream":true}\n\n'
+        'data: {"type":"response.completed","response":{"status":"completed","output":[]}}\n\n'
+        "data: [DONE]\n\n"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -39,3 +39,172 @@ def test_setup_wizard_preserves_existing_llm_api_mode(monkeypatch, tmp_path):
     SetupWizard().run()
 
     assert saved["llm"]["api_mode"] == "responses"
+
+
+def test_setup_wizard_resets_api_mode_when_provider_changes(monkeypatch, tmp_path):
+    saved = {}
+
+    class FakeConfigStore:
+        config_file = tmp_path / "config.yaml"
+
+        def exists(self):
+            return True
+
+        def load(self):
+            return {
+                "claw_type": "hermes",
+                "llm": {
+                    "provider": "hermes-openai-codex",
+                    "model_id": "gpt-5.6-sol",
+                    "api_base": "",
+                    "api_key": "",
+                    "api_mode": "responses",
+                },
+                "proxy": {"port": 30000, "served_model_name": "skillclaw-model"},
+                "skills": {"enabled": False, "dir": str(tmp_path / "skills")},
+                "prm": {"enabled": False},
+                "sharing": {"enabled": False},
+            }
+
+        def save(self, data):
+            saved.update(data)
+
+    def choose(message, choices, default=""):
+        return "openrouter" if message == "LLM provider" else default
+
+    monkeypatch.setattr(setup_wizard, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr(setup_wizard, "_prompt_choice", choose)
+    monkeypatch.setattr(setup_wizard, "_prompt", lambda msg, default="", hide=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_bool", lambda msg, default=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_int", lambda msg, default=0: default)
+
+    SetupWizard().run()
+
+    assert saved["llm"]["provider"] == "openrouter"
+    assert saved["llm"]["api_mode"] == "chat"
+
+
+def test_setup_wizard_configures_hermes_codex_oauth_without_api_key(monkeypatch, tmp_path):
+    saved = {}
+
+    class FakeConfigStore:
+        config_file = tmp_path / "config.yaml"
+
+        def exists(self):
+            return False
+
+        def load(self):
+            return {}
+
+        def save(self, data):
+            saved.update(data)
+
+    monkeypatch.setattr(setup_wizard, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr(setup_wizard, "_validate_hermes_codex_oauth", lambda: None)
+    monkeypatch.setattr(setup_wizard.secrets, "token_urlsafe", lambda _: "generated-proxy-key")
+
+    def choose(message, choices, default=""):
+        if message == "CLI agent to configure":
+            return "hermes"
+        if message == "LLM provider":
+            return "hermes-openai-codex"
+        return default
+
+    monkeypatch.setattr(setup_wizard, "_prompt_choice", choose)
+    monkeypatch.setattr(setup_wizard, "_prompt", lambda msg, default="", hide=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_bool", lambda msg, default=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_int", lambda msg, default=0: default)
+
+    SetupWizard().run()
+
+    assert saved["claw_type"] == "hermes"
+    assert saved["llm"] == {
+        "provider": "hermes-openai-codex",
+        "model_id": "gpt-5.6-sol",
+        "api_base": "",
+        "api_key": "",
+        "api_mode": "responses",
+        "bedrock_region": "",
+    }
+    assert saved["proxy"]["host"] == "127.0.0.1"
+    assert saved["proxy"]["api_key"] == "generated-proxy-key"
+    assert saved["prm"] == {"enabled": False}
+
+
+def test_validate_hermes_codex_oauth_reports_login_remediation(monkeypatch):
+    def unavailable():
+        raise RuntimeError("missing Hermes source")
+
+    monkeypatch.setattr("skillclaw.hermes_codex.resolve_upstream", unavailable)
+
+    try:
+        setup_wizard._validate_hermes_codex_oauth()
+    except RuntimeError as exc:
+        assert "hermes auth add openai-codex" in str(exc)
+    else:
+        raise AssertionError("missing OAuth must fail setup preflight")
+
+
+def test_setup_rejects_codex_oauth_for_non_hermes_adapter(monkeypatch, tmp_path):
+    class FakeConfigStore:
+        config_file = tmp_path / "config.yaml"
+
+        def exists(self):
+            return False
+
+        def load(self):
+            return {}
+
+    monkeypatch.setattr(setup_wizard, "ConfigStore", FakeConfigStore)
+
+    def choose(message, choices, default=""):
+        return "codex" if message == "CLI agent to configure" else "hermes-openai-codex"
+
+    monkeypatch.setattr(setup_wizard, "_prompt_choice", choose)
+
+    try:
+        SetupWizard().run()
+    except ValueError as exc:
+        assert "only supported with the Hermes CLI adapter" in str(exc)
+    else:
+        raise AssertionError("non-Hermes adapters must reject Hermes-owned Codex OAuth")
+
+
+def test_setup_preserves_existing_keyless_prm_url(monkeypatch, tmp_path):
+    saved = {}
+
+    class FakeConfigStore:
+        config_file = tmp_path / "config.yaml"
+
+        def exists(self):
+            return True
+
+        def load(self):
+            return {
+                "claw_type": "hermes",
+                "llm": {
+                    "provider": "hermes-openai-codex",
+                    "model_id": "gpt-5.6-sol",
+                    "api_mode": "responses",
+                },
+                "proxy": {"host": "127.0.0.1", "port": 30001, "api_key": "local-key"},
+                "skills": {"enabled": False, "dir": str(tmp_path / "skills")},
+                "prm": {"enabled": True, "url": "http://local-prm.test/score"},
+                "sharing": {"enabled": False},
+            }
+
+        def save(self, data):
+            saved.update(data)
+
+    monkeypatch.setattr(setup_wizard, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr(setup_wizard, "_validate_hermes_codex_oauth", lambda: None)
+    monkeypatch.setattr(setup_wizard, "_prompt_choice", lambda msg, choices, default="": default)
+    monkeypatch.setattr(setup_wizard, "_prompt", lambda msg, default="", hide=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_bool", lambda msg, default=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_int", lambda msg, default=0: default)
+
+    SetupWizard().run()
+
+    assert saved["prm"]["enabled"] is True
+    assert saved["prm"]["url"] == "http://local-prm.test/score"
+    assert saved["prm"]["api_key"] == ""


### PR DESCRIPTION
## Summary

- add `hermes-openai-codex` as a first-class SkillClaw upstream backed by Hermes-managed ChatGPT/Codex OAuth
- resolve OAuth credentials at request time; access/refresh tokens are never stored in SkillClaw configuration
- preserve native `codex_responses` transport through a named loopback Hermes provider (`custom:skillclaw-codex`)
- force the Codex upstream hop to SSE, then correctly assemble `response.completed` / `response.incomplete` / `response.failed` payloads for non-streaming callers
- make streaming truncation explicit with a sanitized terminal failure event instead of silently returning a partial `200`
- forward required Codex headers (`originator`, Codex `User-Agent`, `ChatGPT-Account-ID`)
- bound OAuth recovery, refresh each identified pool entry at most once per request, and retain 401/429 pool rotation with duplicate-token protection
- allow OAuth bearers only to the canonical HTTPS ChatGPT Codex endpoint
- require both local proxy authentication and a loopback bind at runtime
- honor `$HERMES_HOME` for skills, diagnostics, profile-isolated backups, and restore
- preserve user-owned provider-name collisions; fail safely rather than overwriting `skillclaw-codex`
- retain compatibility with generic non-OAuth providers and document the workflow in English and Chinese

## Security model

Hermes remains the sole owner of ChatGPT/Codex OAuth credentials and refresh locking. SkillClaw receives only a transient access token in memory for the upstream request. OAuth access/refresh tokens are not written to `~/.skillclaw/config.yaml`, Hermes config, error metadata, or logs.

The Hermes-to-SkillClaw hop uses a separate local proxy key. OAuth startup requires a loopback host. Resolver-supplied OAuth endpoints are restricted to `https://chatgpt.com/backend-api/codex` before an Authorization header is sent.

## Merge gate / verification

Repository Actions currently run lint only, so this PR should not merge unless the following focused command passes:

```bash
uv run --extra test pytest -q tests/test_hermes_codex.py tests/test_setup_wizard.py tests/test_responses_native.py
```

Verified on this branch:

- focused OAuth/setup/native Responses suite: **53 passed**
- suite excluding the unrelated dashboard assertion: **154 passed, 1 deselected**
- full suite: **154 passed, 1 pre-existing dashboard failure**
- the same dashboard failure (`tests/test_dashboard.py:1504`, missing `evolve_status["status"]`) reproduces on clean `origin/main`
- `uvx ruff@0.12.2 check .`
- `uvx ruff@0.12.2 format --check .`
- `python -m compileall -q skillclaw tests`
- live E2E, non-streaming: exact reply `SKILLCLAW_HARDENED_NONSTREAM_OK`
- live E2E, streaming: exact reply `SKILLCLAW_HARDENED_STREAM_OK` plus terminal `response.completed`
- live Hermes credential resolution: canonical Codex URL, transient token available, required headers present
- `skillclaw doctor hermes`: **status ok**, `proxy_match: true`
