### PR TITLE
fix: cap evolve LLM summary tokens

### DIFF
--- a/evolve_server/core/config.py
+++ b/evolve_server/core/config.py
@@ -350,6 +350,7 @@ class EvolveServerConfig:
             llm_base_url=llm_base_url,
             llm_model=llm_model,
             llm_api_type=llm_api_type,
+            llm_max_tokens=int(os.environ.get("EVOLVE_LLM_MAX_TOKENS", "8192")),
             evolve_strategy=os.environ.get("EVOLVE_STRATEGY", "dynamic_edit_conservative"),
             use_success_feedback=os.environ.get("EVOLVE_USE_SUCCESS_FEEDBACK", "1").lower() not in {"0", "false", "no"},
             evolve_batch_size=int(os.environ.get("EVOLVE_BATCH_SIZE", "20")),

--- a/evolve_server/pipeline/summarizer.py
+++ b/evolve_server/pipeline/summarizer.py
@@ -395,7 +395,7 @@ async def summarize_session(llm: AsyncLLMClient, session: dict) -> str:
         {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
     ]
     try:
-        return await llm.chat(messages, max_tokens=100000, temperature=0.2)
+        return await llm.chat(messages, max_tokens=min(int(getattr(llm, "max_tokens", 8192) or 8192), 8192), temperature=0.2)
     except Exception as e:
         logger.warning(
             "[Summarizer] LLM call failed for session %s: %s",

--- a/tests/test_evolve_config.py
+++ b/tests/test_evolve_config.py
@@ -1,0 +1,21 @@
+import os
+
+from evolve_server.core.config import EvolveServerConfig
+from skillclaw.config import SkillClawConfig
+
+
+def test_from_skillclaw_config_respects_evolve_llm_max_tokens(monkeypatch):
+    monkeypatch.setenv("EVOLVE_LLM_MAX_TOKENS", "8192")
+    cfg = SkillClawConfig(
+        sharing_enabled=True,
+        sharing_backend="local",
+        sharing_local_root="/tmp/skillclaw-share",
+        sharing_group_id="test-group",
+        llm_api_key="test-key",
+        llm_api_base="https://api.openai.com/v1",
+        llm_model_id="gpt-4o",
+    )
+
+    evolve_cfg = EvolveServerConfig.from_skillclaw_config(cfg)
+
+    assert evolve_cfg.llm_max_tokens == 8192


### PR DESCRIPTION
Respect EVOLVE_LLM_MAX_TOKENS when deriving evolve config from SkillClaw and cap session summarization requests at an OpenAI-compatible ceiling.

Tests: uv run pytest tests/test_evolve_config.py tests/test_skill_backend_config.py -q