### PR TITLE
Refresh MiniMax provider preset to MiniMax-M3 with regional endpoints

### DIFF
--- a/skillclaw/config.py
+++ b/skillclaw/config.py
@@ -65,6 +65,9 @@ class SkillClawConfig:
     # Upstream API surface: "chat" keeps the legacy chat-completions bridge;
     # "responses" forwards Codex /v1/responses payloads to an upstream Responses API.
     llm_api_mode: str = "chat"
+    # Optional provider region tag (e.g. "global_en" / "cn_zh") for providers that
+    # expose region-specific endpoints; otherwise empty.
+    llm_region: str = ""
 
     # ------------------------------------------------------------------ #
     # OpenRouter-specific (ignored for other providers)                    #

--- a/skillclaw/config_store.py
+++ b/skillclaw/config_store.py
@@ -351,6 +351,7 @@ class ConfigStore:
             llm_model_id=llm_model_id,
             llm_api_mode=llm_api_mode,
             bedrock_region=llm.get("bedrock_region") or data.get("bedrock_region", "us-east-1"),
+            llm_region=str(llm.get("region", "") or ""),
             # OpenRouter
             openrouter_app_name=orouter.get("app_name", "SkillClaw"),
             openrouter_app_url=orouter.get("app_url", ""),

--- a/skillclaw/setup_wizard.py
+++ b/skillclaw/setup_wizard.py
@@ -25,7 +25,11 @@ _PROVIDER_PRESETS = {
     },
     "minimax": {
         "api_base": "https://api.minimax.io/v1",
-        "model_id": "MiniMax-M2.7",
+        "model_id": "MiniMax-M3",
+        "regions": {
+            "global_en": "https://api.minimax.io/v1",
+            "cn_zh": "https://api.minimaxi.com/v1",
+        },
     },
     "novita": {
         "api_base": "https://api.novita.ai/openai",
@@ -149,9 +153,22 @@ class SetupWizard:
             )
         else:
             bedrock_region = ""
+            preset_regions = preset.get("regions") or {}
+            default_api_base = current_llm.get("api_base") or preset["api_base"]
+            if preset_regions:
+                region_choices = ["global_en", "cn_zh"]
+                default_region = str(current_llm.get("region") or "global_en")
+                region = _prompt_choice(
+                    "Region",
+                    region_choices,
+                    default=default_region if default_region in region_choices else "global_en",
+                )
+                default_api_base = current_llm.get("api_base") or preset_regions[region]
+            else:
+                region = ""
             api_base = _prompt(
                 "API base URL [http://api.example.com/v1]",
-                default=current_llm.get("api_base") or preset["api_base"],
+                default=default_api_base,
             )
             model_id = _prompt(
                 "Model ID",
@@ -372,6 +389,7 @@ class SetupWizard:
                 "api_key": api_key,
                 "bedrock_region": bedrock_region,
                 "api_mode": llm_api_mode,
+                "region": region,
             },
             "openrouter": openrouter_config,
             "proxy": proxy_config,

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -39,3 +39,72 @@ def test_setup_wizard_preserves_existing_llm_api_mode(monkeypatch, tmp_path):
     SetupWizard().run()
 
     assert saved["llm"]["api_mode"] == "responses"
+
+
+def test_setup_wizard_minimax_preset_defaults_to_m3_and_global_region(monkeypatch, tmp_path):
+    saved = {}
+
+    class FakeConfigStore:
+        config_file = tmp_path / "config.yaml"
+
+        def exists(self):
+            return False
+
+        def load(self):
+            return {}
+
+        def save(self, data):
+            saved.update(data)
+
+    def fake_prompt_choice(msg, choices, default=""):
+        if msg == "LLM provider":
+            return "minimax"
+        return default if default else choices[0]
+
+    monkeypatch.setattr(setup_wizard, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr(setup_wizard, "_prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr(setup_wizard, "_prompt", lambda msg, default="", hide=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_bool", lambda msg, default=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_int", lambda msg, default=0: default)
+
+    SetupWizard().run()
+
+    assert saved["llm"]["provider"] == "minimax"
+    assert saved["llm"]["model_id"] == "MiniMax-M3"
+    assert saved["llm"]["api_base"] == "https://api.minimax.io/v1"
+    assert saved["llm"]["region"] == "global_en"
+
+
+def test_setup_wizard_minimax_preset_china_region_selects_cn_endpoint(monkeypatch, tmp_path):
+    saved = {}
+
+    class FakeConfigStore:
+        config_file = tmp_path / "config.yaml"
+
+        def exists(self):
+            return False
+
+        def load(self):
+            return {}
+
+        def save(self, data):
+            saved.update(data)
+
+    def fake_prompt_choice(msg, choices, default=""):
+        if msg == "LLM provider":
+            return "minimax"
+        if msg == "Region":
+            return "cn_zh"
+        return default if default else choices[0]
+
+    monkeypatch.setattr(setup_wizard, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr(setup_wizard, "_prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr(setup_wizard, "_prompt", lambda msg, default="", hide=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_bool", lambda msg, default=False: default)
+    monkeypatch.setattr(setup_wizard, "_prompt_int", lambda msg, default=0: default)
+
+    SetupWizard().run()
+
+    assert saved["llm"]["provider"] == "minimax"
+    assert saved["llm"]["api_base"] == "https://api.minimaxi.com/v1"
+    assert saved["llm"]["region"] == "cn_zh"


### PR DESCRIPTION
Reason: Refresh the stale MiniMax provider preset to the current model and add the China regional endpoint.

The MiniMax setup preset only exposed the global endpoint `https://api.minimax.io/v1` with `MiniMax-M2.7`. This updates the preset so the current model and both regional endpoints are selectable without manual edits.

Changes:
- Update the MiniMax preset default `model_id` from `MiniMax-M2.7` to `MiniMax-M3`.
- Add a `regions` map to the MiniMax preset covering the global (`https://api.minimax.io/v1`) and China (`https://api.minimaxi.com/v1`) OpenAI-compatible endpoints.
- In the setup wizard, providers that declare `regions` now prompt for a region (`global_en` / `cn_zh`) and default the API base URL to the matching regional endpoint; providers without `regions` are unaffected.
- Persist the selected region as `llm.region` in the generated config and expose it as `SkillClawConfig.llm_region`.

Checks:
- `ruff check .` passes.
- `ruff format --check .` passes.
- `pytest tests/test_setup_wizard.py` (3 passed), including new coverage for the MiniMax preset defaulting to `MiniMax-M3` / `global_en` and selecting the China endpoint when `cn_zh` is chosen.
