### PR TITLE
fix: stop truncating conversation and PRM record files on startup

### DIFF
--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -1495,9 +1495,9 @@ class SkillClawAPIServer:
             os.makedirs(config.record_dir, exist_ok=True)
             self._record_file = os.path.join(config.record_dir, "conversations.jsonl")
             self._prm_record_file = os.path.join(config.record_dir, "prm_scores.jsonl")
-            with open(self._record_file, "w"):
+            with open(self._record_file, "a"):
                 pass
-            with open(self._prm_record_file, "w"):
+            with open(self._prm_record_file, "a"):
                 pass
 
         self.app = self._build_app()


### PR DESCRIPTION
Problem: SkillClawAPIServer.__init__ opens both record files with mode "w" on every boot, wiping all accumulated conversation and PRM score history. Any restart destroys the learning-loop evidence the records are meant to keep.

Root cause: the intent was to ensure the files exist. "w" creates them but also truncates.

Fix: open with "a" instead — creates if missing, appends otherwise. 2 lines.

Verification: restarted the proxy, confirmed conversations.jsonl and prm_scores.jsonl retain prior rows across restarts.

Notes: affects skillclaw/api_server.py only.