### PR TITLE
fix: persist PRM scores for turns judged outside the finalize path

### DIFF
--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -2273,6 +2273,16 @@ class SkillClawAPIServer:
         except Exception:
             return
         self._apply_prm_result(session_id, turn_num, prm_result)
+        # _maybe_finalize_ready_turns (which also writes prm_scores.jsonl)
+        # only processes turns in _pending_turn_data, which is never
+        # populated anywhere. Persist the score here so judged turns are
+        # actually recorded.
+        try:
+            score = prm_result.get("score", 0.0) if isinstance(prm_result, dict) else 0.0
+            votes = prm_result.get("votes", []) if isinstance(prm_result, dict) else []
+            self._append_prm_record(session_id, turn_num, score, votes)
+        except Exception as e:
+            logger.warning("[PRM] record append failed: %s", e)
         if session_id in self._closing_sessions:
             return
         self._maybe_finalize_ready_turns(session_id)


### PR DESCRIPTION
Problem: prm_scores.jsonl never receives rows for turns scored via _flush_pending_record → _fire_prm_scoring → _on_prm_done. The only existing write path for scores is inside _maybe_finalize_ready_turns, which iterates _pending_turn_data — and that dict is never populated anywhere in the codebase. Result: PRM judging runs, _apply_prm_result updates turn records, but the score evidence file stays empty.

Root cause: a scoring flow that works in memory but has no persistence hook; the finalize path that does persist is unreachable.

Fix: _on_prm_done now appends the score row via _append_prm_record after applying the result. The finalize path is untouched, so if _pending_turn_data ever gains population, no double-write occurs (different call sites). 10 lines.

Verification: live proxy, two streamed turns through the chain produced real judge votes recorded in prm_scores.jsonl (3-vote majority, scores and votes persisted).

Notes: affects skillclaw/api_server.py only.