### PR TITLE
fix: dashboard snapshot sync crashes on date fields

### DIFF
--- a/skillclaw/dashboard_store.py
+++ b/skillclaw/dashboard_store.py
@@ -11,7 +11,7 @@ from typing import Any
 
 
 def _json_dumps(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False)
+    return json.dumps(value, ensure_ascii=False, default=str)
 
 
 def _json_loads(raw: str | None, default: Any) -> Any:


### PR DESCRIPTION
Problem: skillclaw dashboard serve crashes during its startup snapshot sync when any skill record contains a date (or datetime) value: TypeError: Object of type date is not JSON serializable. The dashboard then serves with a broken/empty snapshot.

Root cause: _json_dumps in dashboard_store.py calls json.dumps without a default handler, and skill records carry date-typed fields (e.g. created_at/updated_at).

Fix: default=str so non-serializable scalar types degrade to their string form. 1 line.

Verification: dashboard sync now completes and the UI renders skills/validation/session data (warnings: [], correct counts).

Notes: affects skillclaw/dashboard_store.py only.