### PR TITLE
Fix mirror pull failing on nested skill bundles, concurrent pulls, and dashboard sync crash

### DIFF
--- a/skillclaw/cli.py
+++ b/skillclaw/cli.py
@@ -892,6 +892,9 @@ def skills_pull():
     cfg, hub = _require_sharing(cs)
     click.echo(f"Pulling skills from {_sharing_target(cfg)} ...")
     result = hub.pull_skills(cfg.skills_dir)
+    if result.get("locked_out"):
+        click.echo("Skipped: another pull is already running (skills left untouched).")
+        return
     msg = (
         f"Done: {result['downloaded']} downloaded, "
         f"{result['skipped']} unchanged, "

--- a/skillclaw/dashboard_ingest.py
+++ b/skillclaw/dashboard_ingest.py
@@ -18,7 +18,7 @@ import yaml
 from evolve_server.core.skill_registry import SkillIDRegistry
 from evolve_server.core.utils import build_skill_md
 from evolve_server.storage.oss_helpers import fetch_version_bundle, load_version_bundle_record
-from skillclaw.skill_bundle import bundle_entrypoint_text, read_skill_bundle_with_meta
+from skillclaw.skill_bundle import bundle_entrypoint_text, iter_skill_md_paths, read_skill_bundle_with_meta
 
 from .config import SkillClawConfig
 from .skill_hub import SkillHub
@@ -241,7 +241,8 @@ def _load_local_skills(config: SkillClawConfig, warnings: list[str]) -> dict[str
         stats = {}
 
     skills: dict[str, dict[str, Any]] = {}
-    for skill_path in sorted(skills_dir.rglob("SKILL.md")):
+    for skill_md in iter_skill_md_paths(skills_dir):
+        skill_path = Path(skill_md)
         bundle_files, bundle_records, local_tree_sha = read_skill_bundle_with_meta(skill_path.parent)
         try:
             raw = bundle_entrypoint_text(bundle_files)

--- a/skillclaw/dashboard_store.py
+++ b/skillclaw/dashboard_store.py
@@ -11,7 +11,8 @@ from typing import Any
 
 
 def _json_dumps(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False)
+    # date/datetime из фронтматтера скиллов не сериализуются напрямую — пишем ISO-строкой
+    return json.dumps(value, ensure_ascii=False, default=str)
 
 
 def _json_loads(raw: str | None, default: Any) -> Any:

--- a/skillclaw/skill_bundle.py
+++ b/skillclaw/skill_bundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import glob
 import hashlib
 import os
 import shutil
@@ -16,6 +17,34 @@ _IGNORED_SUFFIXES = {".pyc", ".pyo"}
 
 class SkillBundleError(ValueError):
     """Raised when a bundle is malformed or a bundle path is unsafe."""
+
+
+def is_hermes_skill_root(skills_dir: str | os.PathLike[str]) -> bool:
+    """True для каталога скиллов hermes — он один допускает раскладку с категориями."""
+    return os.path.realpath(str(skills_dir)) == os.path.realpath(
+        os.path.join(os.path.expanduser("~"), ".hermes", "skills")
+    )
+
+
+def iter_skill_md_paths(skills_dir: str | os.PathLike[str]) -> list[str]:
+    """Пути к SKILL.md настоящих скиллов — единая точка обхода дерева.
+
+    Скиллом считается <root>/<name> или, в раскладке hermes, <root>/<category>/<name>.
+    SKILL.md глубже — пример или вложенный набор внутри чужого бандла: такие каталоги
+    ломали mirror-pull (удалялись как stale вместе с родителем) и засоряли каталог
+    скиллов, доступных агенту.
+    """
+    root = str(skills_dir)
+    if not is_hermes_skill_root(root):
+        return sorted(glob.glob(os.path.join(root, "*", _BUNDLE_ENTRYPOINT)))
+
+    out: list[str] = []
+    for path in glob.glob(os.path.join(root, "**", _BUNDLE_ENTRYPOINT), recursive=True):
+        rel = os.path.relpath(os.path.dirname(path), root)
+        if len(rel.split(os.sep)) > 2:
+            continue
+        out.append(path)
+    return sorted(out)
 
 
 def _coerce_bytes(data: bytes | bytearray | str) -> bytes:

--- a/skillclaw/skill_hub.py
+++ b/skillclaw/skill_hub.py
@@ -16,7 +16,6 @@ Usage:
 from __future__ import annotations
 
 import fcntl
-import glob
 import hashlib
 import json
 import logging
@@ -34,6 +33,7 @@ from .skill_bundle import (
     bundle_file_records,
     bundle_has_only_entrypoint,
     bundle_tree_sha256,
+    iter_skill_md_paths,
     read_skill_bundle_with_meta,
     write_skill_bundle,
 )
@@ -361,12 +361,7 @@ class SkillHub:
 
         Returns {"uploaded": N, "skipped": M, "filtered": F, "total_local": T}.
         """
-        # тот же обход, что и у pull, — иначе вложенные примеры уезжают на хаб как отдельные скиллы
-        paths = sorted(
-            os.path.join(skill_dir, "SKILL.md")
-            for dirs in self._list_local_skill_dirs(skills_dir).values()
-            for skill_dir in dirs
-        )
+        paths = iter_skill_md_paths(skills_dir)
         if not paths:
             logger.info("[SkillHub] no local skills to push")
             return {"uploaded": 0, "skipped": 0, "filtered": 0, "total_local": 0}
@@ -509,22 +504,9 @@ class SkillHub:
         out: dict[str, list[str]] = {}
         if not os.path.isdir(skills_dir):
             return out
-        if _is_hermes_skill_root(skills_dir):
-            for path in sorted(glob.glob(os.path.join(skills_dir, "**", "SKILL.md"), recursive=True)):
-                skill_dir = os.path.dirname(path)
-                # раскладка hermes — <root>/<name> или <root>/<category>/<name>;
-                # SKILL.md глубже — это пример внутри чужого бандла, а не отдельный скилл
-                if len(os.path.relpath(skill_dir, skills_dir).split(os.sep)) > 2:
-                    continue
-                name = os.path.basename(skill_dir)
-                out.setdefault(name, []).append(skill_dir)
-            return out
-        for entry in os.scandir(skills_dir):
-            if not entry.is_dir():
-                continue
-            skill_md = os.path.join(entry.path, "SKILL.md")
-            if os.path.isfile(skill_md):
-                out.setdefault(entry.name, []).append(entry.path)
+        for path in iter_skill_md_paths(skills_dir):
+            skill_dir = os.path.dirname(path)
+            out.setdefault(os.path.basename(skill_dir), []).append(skill_dir)
         return out
 
     @classmethod

--- a/skillclaw/skill_hub.py
+++ b/skillclaw/skill_hub.py
@@ -15,12 +15,14 @@ Usage:
 
 from __future__ import annotations
 
+import fcntl
 import glob
 import hashlib
 import json
 import logging
 import os
 import shutil
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any, Collection, Optional
 
@@ -37,6 +39,42 @@ from .skill_bundle import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _pull_lock(skills_dir: str):
+    """Межпроцессный лок на pull: launchd-инстанс, поллер и CLI ходят в один каталог.
+
+    Отдаёт False, если pull уже идёт где-то ещё, — цикл просто пропускается.
+    """
+    lock_path = os.path.join(os.path.dirname(os.path.abspath(skills_dir)), ".skillclaw_pull.lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _restore_skills_dir(skills_dir: str, backup_dir: str, stamp: str) -> None:
+    """Откат на бэкап: сначала уводим сломанный каталог целиком, потом кладём копию.
+
+    rmtree по месту оставлял недоудалённые каталоги и валился на `Directory not empty`.
+    """
+    broken_dir = f"{skills_dir}.broken_{stamp}"
+    if os.path.isdir(skills_dir):
+        os.rename(skills_dir, broken_dir)
+    try:
+        shutil.copytree(backup_dir, skills_dir)
+    finally:
+        shutil.rmtree(broken_dir, ignore_errors=True)
 
 
 def _is_hermes_skill_root(skills_dir: str) -> bool:
@@ -559,6 +597,33 @@ class SkillHub:
         skip_names: Optional[Collection[str]] = None,
         include_names: Optional[Collection[str]] = None,
     ) -> dict[str, Any]:
+        """Serialize pulls across processes, then delegate to :meth:`_pull_skills_locked`."""
+        with _pull_lock(skills_dir) as acquired:
+            if not acquired:
+                logger.info("[SkillHub] pull already running in another process, cycle skipped")
+                return {
+                    "downloaded": 0,
+                    "skipped": 0,
+                    "deleted": 0,
+                    "total_remote": 0,
+                    "restored_from_backup": False,
+                    "backup_dir": "",
+                    "locked_out": True,
+                }
+            return self._pull_skills_locked(
+                skills_dir,
+                mirror=mirror,
+                skip_names=skip_names,
+                include_names=include_names,
+            )
+
+    def _pull_skills_locked(
+        self,
+        skills_dir: str,
+        mirror: bool = True,
+        skip_names: Optional[Collection[str]] = None,
+        include_names: Optional[Collection[str]] = None,
+    ) -> dict[str, Any]:
         """Mirror cloud skills to local directory with backup + rollback safety.
 
         Parameters
@@ -788,9 +853,7 @@ class SkillHub:
         except Exception as e:
             logger.warning("[SkillHub] mirror pull failed, restoring backup: %s", e)
             try:
-                if os.path.isdir(skills_dir):
-                    shutil.rmtree(skills_dir)
-                shutil.copytree(backup_dir, skills_dir)
+                _restore_skills_dir(skills_dir, backup_dir, stamp)
                 restored_from_backup = True
                 logger.info("[SkillHub] local skills restored from backup: %s", backup_dir)
             except Exception as restore_err:

--- a/skillclaw/skill_hub.py
+++ b/skillclaw/skill_hub.py
@@ -557,6 +557,31 @@ class SkillHub:
             shutil.rmtree(skill_dir)
             logger.info("[SkillHub] removed duplicate local skill dir: %s", skill_dir)
 
+    def _mirror_pull_is_noop(
+        self,
+        skills_dir: str,
+        manifest: dict[str, dict[str, Any]],
+        local_skills: dict[str, str],
+        local_dirs_by_name: dict[str, list[str]],
+        skip_set: set[str],
+    ) -> bool:
+        """True, если mirror-pull ничего не изменит: нет stale, дублей и расхождений по хэшу."""
+        if set(local_skills) - set(manifest):
+            return False
+        if any(len(dirs) > 1 for dirs in local_dirs_by_name.values()):
+            return False
+
+        for name, rec in manifest.items():
+            category = str(rec.get("category", "general") or "general")
+            target_dir = self._resolve_pull_target_dir(skills_dir, name, category, local_dirs_by_name)
+            if name in skip_set:
+                if not os.path.exists(os.path.join(target_dir, "SKILL.md")):
+                    return False
+                continue
+            if not os.path.isdir(target_dir) or not self._local_bundle_matches_record(target_dir, rec):
+                return False
+        return True
+
     @staticmethod
     def _prune_backups(backup_root: str, prefix: str, keep: int = 3) -> None:
         """Keep only newest `keep` backups for current skills dir."""
@@ -741,6 +766,19 @@ class SkillHub:
             return _result(
                 downloaded=downloaded,
                 skipped=skipped,
+                deleted=0,
+                total_remote=len(manifest),
+                restored_from_backup=False,
+                backup_dir="",
+            )
+
+        # Сверяем хэши до копирования: mirror-pull переписывает весь каталог (бэкап + staging)
+        # на каждом цикле поллера, а обычно менять нечего — 102 скилла копировались раз в 30 секунд.
+        if self._mirror_pull_is_noop(skills_dir, manifest, local_skills, local_dirs_by_name, skip_set):
+            logger.info("[SkillHub] pull complete: 0 downloaded, %d skipped, 0 deleted, %d total remote", len(manifest), len(manifest))
+            return _result(
+                downloaded=0,
+                skipped=len(manifest),
                 deleted=0,
                 total_remote=len(manifest),
                 restored_from_backup=False,

--- a/skillclaw/skill_hub.py
+++ b/skillclaw/skill_hub.py
@@ -323,10 +323,12 @@ class SkillHub:
 
         Returns {"uploaded": N, "skipped": M, "filtered": F, "total_local": T}.
         """
-        if _is_hermes_skill_root(skills_dir):
-            paths = sorted(glob.glob(os.path.join(skills_dir, "**", "SKILL.md"), recursive=True))
-        else:
-            paths = sorted(glob.glob(os.path.join(skills_dir, "*", "SKILL.md")))
+        # тот же обход, что и у pull, — иначе вложенные примеры уезжают на хаб как отдельные скиллы
+        paths = sorted(
+            os.path.join(skill_dir, "SKILL.md")
+            for dirs in self._list_local_skill_dirs(skills_dir).values()
+            for skill_dir in dirs
+        )
         if not paths:
             logger.info("[SkillHub] no local skills to push")
             return {"uploaded": 0, "skipped": 0, "filtered": 0, "total_local": 0}
@@ -472,6 +474,10 @@ class SkillHub:
         if _is_hermes_skill_root(skills_dir):
             for path in sorted(glob.glob(os.path.join(skills_dir, "**", "SKILL.md"), recursive=True)):
                 skill_dir = os.path.dirname(path)
+                # раскладка hermes — <root>/<name> или <root>/<category>/<name>;
+                # SKILL.md глубже — это пример внутри чужого бандла, а не отдельный скилл
+                if len(os.path.relpath(skill_dir, skills_dir).split(os.sep)) > 2:
+                    continue
                 name = os.path.basename(skill_dir)
                 out.setdefault(name, []).append(skill_dir)
             return out
@@ -756,7 +762,11 @@ class SkillHub:
             remote_names = set(manifest.keys())
             local_names = set(local_skills.keys())
             for stale in sorted(local_names - remote_names):
-                shutil.rmtree(local_skills[stale], ignore_errors=False)
+                stale_dir = local_skills[stale]
+                # каталог мог уйти вместе с родительским скиллом — это не повод откатывать весь pull
+                if not os.path.isdir(stale_dir):
+                    continue
+                shutil.rmtree(stale_dir, ignore_errors=True)
                 deleted += 1
 
             for name in sorted(remote_names):

--- a/skillclaw/skill_manager.py
+++ b/skillclaw/skill_manager.py
@@ -47,7 +47,6 @@ Valid categories: general, coding, research, data_analysis, security,
                   communication, automation, agentic, productivity, common_mistakes
 """
 
-import glob
 import hashlib
 import json
 import logging
@@ -59,7 +58,7 @@ from typing import Any, Dict, Optional
 
 import yaml
 
-from .skill_bundle import list_skill_bundle_paths
+from .skill_bundle import iter_skill_md_paths, list_skill_bundle_paths
 
 logger = logging.getLogger(__name__)
 
@@ -318,11 +317,7 @@ class SkillManager:
         return result
 
     def _skill_md_paths(self) -> list[str]:
-        if self._is_hermes_skill_root():
-            pattern = os.path.join(self._skills_dir, "**", "SKILL.md")
-            return sorted(glob.glob(pattern, recursive=True))
-        pattern = os.path.join(self._skills_dir, "*", "SKILL.md")
-        return sorted(glob.glob(pattern))
+        return iter_skill_md_paths(self._skills_dir)
 
     def _compute_skills_fingerprint(self) -> tuple[tuple[str, int, int], ...]:
         fingerprint: list[tuple[str, int, int]] = []


### PR DESCRIPTION
Four independent failures hit while running SkillClaw against a Hermes skills directory. Each is reproducible and fixed separately.

### 1. Mirror pull fails permanently when a skill bundle contains nested SKILL.md files

`_list_local_skill_dirs` globs `SKILL.md` at any depth, so examples shipped inside a skill (e.g. `claudeception/examples/*`) are listed as standalone local skills. They are absent from the remote manifest, so mirror pull deletes them as stale — the parent directory first, then `rmtree` hits the now-missing nested paths with `ignore_errors=False`:

```
[SkillHub] mirror pull failed, restoring backup: [Errno 2] No such file or directory:
  '.../skills/claudeception/examples/nextjs-server-side-error-debugging'
[SkillHub] skill pull: 0 downloaded, 0 unchanged, 0 failed, 0 deleted, 101 total remote
```

Every pull rolled back, so nothing was ever downloaded. `push_skills` had the same unbounded glob and would have uploaded those nested examples to the hub as separate skills.

### 2. Concurrent pulls corrupt the skills directory

`pull_skills` is called by the launcher's auto-pull, the 30s reload poller and the CLI, with no mutual exclusion. Two overlapping pulls walk the same directory and one moves bundles out of staging while the other is still reading them, producing a burst of `FileNotFoundError` across unrelated skills.

### 3. Backup rollback fails exactly when needed

The rollback path does `rmtree(skills_dir)` then `copytree(backup_dir, skills_dir)`. When the tree is being mutated concurrently, `rmtree` leaves directories behind and the restore aborts:

```
[SkillHub] backup restore failed: [Errno 66] Directory not empty: '.../skills/productivity'
```

### 4. `dashboard sync` crashes on date frontmatter

`TypeError: Object of type date is not JSON serializable` — PyYAML parses a bare `date:` value in skill frontmatter into `datetime.date`, which `json.dumps` rejects.

## Changes

- Bound skill discovery to the supported layouts (`<root>/<name>`, and `<root>/<category>/<name>` for the hermes root); nested `SKILL.md` files are bundle contents, not skills.
- Extract that walk into `skill_bundle.iter_skill_md_paths` and route `skill_hub`, `skill_manager` and `dashboard_ingest` through it — they previously used three different rules, which is why the loader reported 105 skills and the dashboard 106 where the disk had 102.
- Skip stale entries already removed together with a parent directory.
- Guard `pull_skills` with a non-blocking `flock`; a busy lock returns `locked_out` and the cycle is skipped rather than racing. Surfaced in the CLI so a skipped pull is not mistaken for a successful empty one.
- Rename the broken directory aside before restoring the backup, so rollback cannot trip over its own leftovers.
- Serialize `date`/`datetime` values when writing the dashboard snapshot.

## Verification

- Fixture with a nested example bundle and a nested `.claude/skills` set: `iter_skill_md_paths`, `SkillHub._list_local_skills` and `SkillManager` all return the same 3 skills; before the change the latter two returned 5.
- Lock: a second concurrent acquisition returns `False` and the lock is released afterwards. Four concurrent `skillclaw skills pull` runs against a live daemon — exactly one proceeds, three report `Skipped: another pull is already running`, and the skills directory is untouched.
- Rollback: restoring over a directory holding leftovers from a half-written pull now succeeds and cleans up after itself; the previous code raised `Directory not empty`.
- On a real 102-skill library the daemon now logs `pull complete: 0 downloaded, 102 skipped, 0 deleted, 102 total remote` on every cycle, with no rollbacks, and loader/hub/dashboard all report 102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)