### PR TITLE
chore: restore Ruff baseline

### DIFF
--- a/skillclaw/config_store.py
+++ b/skillclaw/config_store.py
@@ -39,6 +39,7 @@ def _resolve_config_file(config_file: Path | None = None) -> Path:
 
     return CONFIG_FILE
 
+
 _DEFAULTS: dict = {
     "llm": {
         "provider": "custom",

--- a/skillclaw/embedding_api_client.py
+++ b/skillclaw/embedding_api_client.py
@@ -10,9 +10,10 @@ Supports any embedding service with OpenAI API format, including:
 """
 
 import logging
+from typing import List, Optional
+
 import numpy as np
 import requests
-from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -67,9 +68,7 @@ class EmbeddingAPIClient:
             numpy array of shape (len(texts), embedding_dim)
         """
         if show_progress_bar:
-            logger.warning(
-                "show_progress_bar parameter is not supported for embedding API client and will be ignored"
-            )
+            logger.warning("show_progress_bar parameter is not supported for embedding API client and will be ignored")
 
         if not texts:
             return np.zeros((0, 0), dtype=np.float32)
@@ -132,9 +131,7 @@ class EmbeddingAPIClient:
             dtype=np.float32,
         )
 
-        logger.debug(
-            f"Retrieved {len(embeddings)} embeddings with dimension {embeddings.shape[1]}"
-        )
+        logger.debug(f"Retrieved {len(embeddings)} embeddings with dimension {embeddings.shape[1]}")
         return embeddings
 
     def __del__(self):

--- a/skillclaw/skill_manager.py
+++ b/skillclaw/skill_manager.py
@@ -386,9 +386,7 @@ class SkillManager:
             if self.embedding_type == "api":
                 # Use OpenAI-compatible API
                 if not self.embedding_api_url or not self.embedding_api_model:
-                    raise ValueError(
-                        "embedding_api_url and embedding_api_model must be set when embedding_type='api'"
-                    )
+                    raise ValueError("embedding_api_url and embedding_api_model must be set when embedding_type='api'")
                 from .embedding_api_client import EmbeddingAPIClient
 
                 logger.info(

--- a/tests/test_embedding_api.py
+++ b/tests/test_embedding_api.py
@@ -4,11 +4,9 @@ Unit tests for embedding API client.
 Run with: pytest tests/test_embedding_api.py
 """
 
-import json
 import numpy as np
 import pytest
 import responses
-from unittest.mock import MagicMock, patch
 
 from skillclaw.embedding_api_client import EmbeddingAPIClient
 
@@ -99,7 +97,7 @@ class TestEmbeddingAPIClient:
             api_key="secret-key-123",
         )
 
-        embeddings = client.encode(["test"])
+        client.encode(["test"])
 
         # Check that request includes Authorization header
         assert len(responses.calls) == 1
@@ -121,7 +119,7 @@ class TestEmbeddingAPIClient:
             api_key=None,
         )
 
-        embeddings = client.encode(["test"])
+        client.encode(["test"])
 
         # Check that request does not include Authorization header
         assert len(responses.calls) == 1
@@ -200,8 +198,7 @@ class TestEmbeddingAPIClient:
 
         # Generate mock embeddings
         embeddings_data = [
-            {"embedding": list(np.random.rand(embedding_dim).astype(float)), "index": i}
-            for i in range(num_texts)
+            {"embedding": list(np.random.rand(embedding_dim).astype(float)), "index": i} for i in range(num_texts)
         ]
 
         responses.add(
@@ -229,13 +226,14 @@ class TestEmbeddingAPIIntegration:
     @pytest.mark.skipif(True, reason="Requires actual API key")
     def test_skill_manager_with_api(self):
         """Test SkillManager integration with embedding API.
-        
+
         This test is skipped by default as it requires a real API key.
         Set embedding API credentials and remove @skipif to run.
         """
-        from skillclaw.skill_manager import SkillManager
-        from pathlib import Path
         import tempfile
+        from pathlib import Path
+
+        from skillclaw.skill_manager import SkillManager
 
         # Create temporary skill directory
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- sort the embedding client/test imports and remove unused test imports
- stop assigning unused embedding results in header tests
- apply the repository's Ruff formatter to the two remaining out-of-format modules

## Verification

- `uvx ruff@0.12.2 check .`
- `uvx ruff@0.12.2 format --check .`
- `pytest -q tests/test_embedding_api.py` — 9 passed, 1 skipped
- full suite remains at the pre-existing baseline: 1 dashboard failure, 130 passed, 1 skipped