### PR TITLE
fix: bound prompt truncation loop

### DIFF
--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -3188,7 +3188,8 @@ class SkillClawAPIServer:
         def _prompt_len(msgs):
             return _estimate_openai_body_input_tokens({"messages": msgs, "tools": tools})
 
-        if _prompt_len(messages) <= max_prompt_tokens:
+        original_tokens = _prompt_len(messages)
+        if original_tokens <= max_prompt_tokens:
             return messages
 
         # Split into system and non-system messages
@@ -3196,20 +3197,27 @@ class SkillClawAPIServer:
         non_sys = [m for m in messages if m.get("role") != "system"]
 
         dropped = 0
-        while len(non_sys) > 1:
-            candidate = sys_msgs + non_sys[dropped + 1 :]
-            if _prompt_len(candidate) <= max_prompt_tokens:
-                dropped += 1
-                break
+        while len(non_sys) - dropped > 1:
             dropped += 1
+            candidate = sys_msgs + non_sys[dropped:]
+            if _prompt_len(candidate) <= max_prompt_tokens:
+                break
 
         result = sys_msgs + non_sys[dropped:]
+        result_tokens = _prompt_len(result)
         if dropped:
             logger.info(
                 "[OpenClaw] context truncated: dropped %d oldest messages (%d -> %d est tokens, limit=%d)",
                 dropped,
-                _prompt_len(messages),
-                _prompt_len(result),
+                original_tokens,
+                result_tokens,
+                max_prompt_tokens,
+            )
+        if result_tokens > max_prompt_tokens:
+            logger.warning(
+                "[OpenClaw] context remains over limit after preserving system messages and the newest message "
+                "(%d est tokens, limit=%d)",
+                result_tokens,
                 max_prompt_tokens,
             )
         return result

--- a/tests/test_prompt_truncation.py
+++ b/tests/test_prompt_truncation.py
@@ -1,0 +1,23 @@
+from skillclaw.api_server import SkillClawAPIServer, _estimate_openai_body_input_tokens
+
+
+def _truncate(messages: list[dict], max_prompt_tokens: int) -> list[dict]:
+    server = object.__new__(SkillClawAPIServer)
+    return server._truncate_messages(messages, tools=None, max_prompt_tokens=max_prompt_tokens)
+
+
+def test_truncation_stops_when_system_message_alone_exceeds_budget() -> None:
+    system = {"role": "system", "content": "x" * 100_000}
+    older = {"role": "user", "content": "old"}
+    newest = {"role": "user", "content": "new"}
+
+    assert _truncate([system, older, newest], max_prompt_tokens=1) == [system, newest]
+
+
+def test_truncation_drops_only_messages_needed_to_fit() -> None:
+    system = {"role": "system", "content": "system"}
+    older = {"role": "user", "content": "x" * 20_000}
+    newest = {"role": "user", "content": "keep me"}
+    limit = _estimate_openai_body_input_tokens({"messages": [system, newest], "tools": None})
+
+    assert _truncate([system, older, newest], max_prompt_tokens=limit) == [system, newest]


### PR DESCRIPTION
## Summary

- bound the oldest-message truncation loop by the number of non-system messages
- preserve system messages and the newest non-system message when the prompt cannot fit
- log the remaining over-budget condition instead of spinning forever
- avoid recalculating the original/result token estimates for logging

Closes #77.

## Verification

- `pytest -q tests/test_prompt_truncation.py` — 2 passed
- `uvx ruff@0.12.2 check .`
- `uvx ruff@0.12.2 format --check .`
- full suite: 1 pre-existing dashboard failure, 132 passed, 1 skipped