### PR TITLE
fix: reject unsafe skill bundle paths

### DIFF
--- a/skillclaw/skill_bundle.py
+++ b/skillclaw/skill_bundle.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import os
 import shutil
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Iterable, Mapping
 
 _BUNDLE_ENTRYPOINT = "SKILL.md"
@@ -30,12 +30,32 @@ def normalize_bundle_rel_path(rel_path: str) -> str:
     value = str(rel_path or "").strip().replace("\\", "/")
     if not value:
         raise SkillBundleError("Bundle path must not be empty")
-    parts = PurePosixPath(value).parts
+    posix_path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if posix_path.is_absolute() or windows_path.is_absolute() or windows_path.drive:
+        raise SkillBundleError(f"Bundle path must be relative: {rel_path!r}")
+    parts = posix_path.parts
     if not parts:
         raise SkillBundleError("Bundle path must not be empty")
     if any(part in {"", ".", ".."} for part in parts):
         raise SkillBundleError(f"Unsafe bundle path: {rel_path!r}")
     return "/".join(parts)
+
+
+def normalize_skill_path_segment(value: str, field: str) -> str:
+    """Validate a remote name/category before using it as one directory segment."""
+    segment = str(value or "").strip()
+    normalized = segment.replace("\\", "/")
+    windows_path = PureWindowsPath(normalized)
+    if (
+        not segment
+        or "\x00" in segment
+        or windows_path.drive
+        or len(PurePosixPath(normalized).parts) != 1
+        or segment in {".", ".."}
+    ):
+        raise SkillBundleError(f"Unsafe {field}: {value!r}")
+    return segment
 
 
 def is_ignored_bundle_rel_path(rel_path: str) -> bool:
@@ -146,12 +166,21 @@ def write_skill_bundle(
     clean: bool = False,
 ) -> None:
     root = Path(skill_dir)
+    root_resolved = root.resolve(strict=False)
+    planned_writes: list[tuple[Path, bytes]] = []
+    for rel_path, data in sorted(coerce_skill_bundle(bundle_files).items()):
+        path = root / Path(rel_path)
+        try:
+            path.resolve(strict=False).relative_to(root_resolved)
+        except ValueError as exc:
+            raise SkillBundleError(f"Bundle path escapes skill directory: {rel_path!r}") from exc
+        planned_writes.append((path, data))
+
     if clean and root.exists():
         shutil.rmtree(root)
     root.mkdir(parents=True, exist_ok=True)
 
-    for rel_path, data in sorted(coerce_skill_bundle(bundle_files).items()):
-        path = root / Path(rel_path)
+    for path, data in planned_writes:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
 

--- a/skillclaw/skill_hub.py
+++ b/skillclaw/skill_hub.py
@@ -32,6 +32,7 @@ from .skill_bundle import (
     bundle_file_records,
     bundle_has_only_entrypoint,
     bundle_tree_sha256,
+    normalize_skill_path_segment,
     read_skill_bundle_with_meta,
     write_skill_bundle,
 )
@@ -44,6 +45,8 @@ def _is_hermes_skill_root(skills_dir: str) -> bool:
 
 
 def _skill_dir_for_root(skills_dir: str, skill_name: str, category: str = "general") -> str:
+    skill_name = normalize_skill_path_segment(skill_name, "skill name")
+    category = normalize_skill_path_segment(category or "general", "skill category")
     if _is_hermes_skill_root(skills_dir) and category and category != "general":
         return os.path.join(skills_dir, category, skill_name)
     return os.path.join(skills_dir, skill_name)

--- a/tests/test_skill_path_safety.py
+++ b/tests/test_skill_path_safety.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from skillclaw.object_store import LocalObjectStore
+from skillclaw.skill_bundle import SkillBundleError, normalize_bundle_rel_path, write_skill_bundle
+from skillclaw.skill_hub import SkillHub, _skill_dir_for_root
+
+
+@pytest.mark.parametrize(
+    "unsafe_path",
+    ["/tmp/escaped", "C:/tmp/escaped", "C:\\tmp\\escaped", "//server/share/escaped"],
+)
+def test_bundle_paths_must_be_relative(unsafe_path: str) -> None:
+    with pytest.raises(SkillBundleError):
+        normalize_bundle_rel_path(unsafe_path)
+
+
+@pytest.mark.parametrize("unsafe_name", ["../outside", "nested/skill", "nested\\skill", "C:/outside"])
+def test_remote_skill_names_cannot_select_another_directory(tmp_path: Path, unsafe_name: str) -> None:
+    with pytest.raises(SkillBundleError):
+        _skill_dir_for_root(str(tmp_path / "skills"), unsafe_name)
+
+
+def test_remote_skill_categories_must_be_single_segments(tmp_path: Path) -> None:
+    with pytest.raises(SkillBundleError):
+        _skill_dir_for_root(str(tmp_path / "skills"), "safe-skill", "../outside")
+
+
+def test_bundle_write_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = tmp_path / "skill"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    (root / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(SkillBundleError):
+        write_skill_bundle(
+            root,
+            {
+                "SKILL.md": b"---\nname: safe\n---\n",
+                "linked/escaped.txt": b"escaped",
+            },
+        )
+
+    assert not (outside / "escaped.txt").exists()
+
+
+def test_pull_rejects_manifest_name_that_escapes_skills_root(tmp_path: Path) -> None:
+    store_root = tmp_path / "store"
+    skills_dir = tmp_path / "victim" / "skills"
+    store = LocalObjectStore(str(store_root))
+    store.put_object(
+        "default/manifest.jsonl",
+        (json.dumps({"name": "../outside/pwned", "category": "general"}) + "\n").encode(),
+    )
+    hub = SkillHub(
+        backend="local",
+        endpoint="",
+        bucket="",
+        access_key_id="",
+        secret_access_key="",
+        local_root=str(store_root),
+        group_id="default",
+    )
+
+    with pytest.raises(SkillBundleError):
+        hub.pull_skills(str(skills_dir), mirror=False)
+
+    assert not (tmp_path / "victim" / "outside" / "pwned" / "SKILL.md").exists()


### PR DESCRIPTION
## Summary

- reject POSIX absolute, Windows absolute/drive, and UNC bundle paths
- validate remote skill names and categories before using them as directory segments
- resolve every planned bundle write under the skill root before deleting or writing anything
- reject symlink-based escapes as defense in depth
- add pull-level regression coverage for a malicious manifest name

Closes #68.
Closes #69.

## Verification

- `pytest -q tests/test_skill_path_safety.py tests/test_skill_bundle_support.py` — 19 passed
- `uvx ruff@0.12.2 check .`
- `uvx ruff@0.12.2 format --check .`
- full suite: 1 pre-existing dashboard failure, 141 passed, 1 skipped