### PR TITLE
fix: move blocking storage I/O off event loop

### DIFF
--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -3079,7 +3079,7 @@ class SkillClawAPIServer:
 
             content = json.dumps(session_payload, ensure_ascii=False)
             oss_key = f"{hub._prefix()}sessions/{session_id}.json"
-            hub._bucket.put_object(oss_key, content.encode("utf-8"))
+            await asyncio.to_thread(hub._bucket.put_object, oss_key, content.encode("utf-8"))
             logger.info(
                 "[SkillHub] session uploaded: %s (%d turns, %d bytes)",
                 oss_key,
@@ -3153,7 +3153,11 @@ class SkillClawAPIServer:
             from .skill_hub import SkillHub
 
             hub = SkillHub.from_config(self.config)
-            pull_result = hub.pull_skills(self.config.skills_dir, skip_names=skip_names)
+            pull_result = await asyncio.to_thread(
+                hub.pull_skills,
+                self.config.skills_dir,
+                skip_names=skip_names,
+            )
             logger.info(
                 "[SkillHub] skill pull: %d downloaded, %d unchanged, %d failed, %d deleted, %d total remote",
                 pull_result["downloaded"],

--- a/tests/test_async_storage_io.py
+++ b/tests/test_async_storage_io.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from skillclaw.api_server import SkillClawAPIServer
+from skillclaw.config import SkillClawConfig
+from skillclaw.skill_hub import SkillHub
+
+
+@pytest.mark.anyio
+async def test_session_upload_runs_object_store_write_in_worker_thread(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    class Bucket:
+        def put_object(self, key, data):
+            calls.append(("put", key, data))
+
+    class Hub:
+        _bucket = Bucket()
+
+        @staticmethod
+        def _prefix():
+            return "group/"
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append(("to_thread", func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(SkillHub, "object_storage_from_config", classmethod(lambda cls, config: Hub()))
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(sharing_enabled=True, sharing_group_id="group")
+
+    assert await server._upload_session_data("session-1", [{"turn_num": 1}]) is True
+    assert calls[0][0] == "to_thread"
+    assert calls[1][0] == "put"
+
+
+@pytest.mark.anyio
+async def test_skill_pull_runs_storage_sync_in_worker_thread(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    class Hub:
+        def pull_skills(self, skills_dir, *, skip_names=None):
+            calls.append(("pull", skills_dir, skip_names))
+            return {
+                "downloaded": 0,
+                "skipped": 1,
+                "failed": 0,
+                "deleted": 0,
+                "total_remote": 1,
+                "restored_from_backup": False,
+            }
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append(("to_thread", func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(SkillHub, "from_config", classmethod(lambda cls, config: Hub()))
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    server = object.__new__(SkillClawAPIServer)
+    server.config = SkillClawConfig(sharing_enabled=True, skills_dir=str(tmp_path / "skills"))
+    server.skill_manager = None
+
+    await server._pull_skills_from_cloud(skip_names={"local-only"})
+    assert calls[0][0] == "to_thread"
+    assert calls[1] == ("pull", str(tmp_path / "skills"), {"local-only"})


### PR DESCRIPTION
## Summary

- run session object-store writes through `asyncio.to_thread`
- run periodic skill pulls through `asyncio.to_thread`
- keep reload and logging behavior on the event-loop thread
- add regression coverage that both synchronous storage calls cross the worker-thread boundary

Closes #52.

## Verification

- `pytest -q tests/test_async_storage_io.py tests/test_session_upload_trigger.py` — 11 passed
- `uvx ruff@0.12.2 check .`
- `uvx ruff@0.12.2 format --check .`
- full suite: 1 pre-existing dashboard failure, 132 passed, 1 skipped