### PR TITLE
feat: add codex_oauth provider for ChatGPT-account authentication

### DIFF
--- a/evolve_server/core/config.py
+++ b/evolve_server/core/config.py
@@ -289,8 +289,21 @@ class EvolveServerConfig:
             or ""
         )
         local_root = str(getattr(config, "sharing_local_root", "") or os.environ.get("EVOLVE_LOCAL_ROOT", ""))
-        llm_api_key = config.llm_api_key or config.prm_api_key
-        llm_base_url = config.llm_api_base or config.prm_url
+        # Default to SkillClaw's own upstream, but let the environment override.
+        # This matters when SkillClaw authenticates via ``codex_oauth``: the
+        # inherited api_key is empty (auth is an on-disk OAuth token, not a
+        # static key), so the evolve server must instead be pointed at the
+        # SkillClaw proxy, which performs the OAuth handshake on its behalf.
+        llm_api_key = _first_env(
+            "EVOLVE_LLM_API_KEY",
+            "OPENAI_API_KEY",
+            default=config.llm_api_key or config.prm_api_key,
+        )
+        llm_base_url = _first_env(
+            "EVOLVE_LLM_BASE_URL",
+            "OPENAI_BASE_URL",
+            default=config.llm_api_base or config.prm_url,
+        )
         llm_model = os.environ.get("EVOLVE_MODEL", config.llm_model_id or "gpt-4o")
         llm_api_type = os.environ.get("EVOLVE_LLM_API_TYPE", "openai-completions")
 

--- a/skillclaw/api_server.py
+++ b/skillclaw/api_server.py
@@ -2559,6 +2559,34 @@ class SkillClawAPIServer:
         """Return whether /v1/responses should be forwarded as Responses API."""
         return str(getattr(self.config, "llm_api_mode", "chat") or "chat").lower() == "responses"
 
+    def _codex_oauth_enabled(self) -> bool:
+        """Return whether upstream auth should use ChatGPT-account OAuth."""
+        return str(getattr(self.config, "llm_provider", "") or "").strip().lower() == "codex_oauth"
+
+    def _build_upstream_auth_headers(self, api_base: str) -> dict[str, str]:
+        """Build upstream auth headers for the configured provider.
+
+        For ``codex_oauth`` this resolves a live ChatGPT-account OAuth token
+        (refreshing it only when actually expired) plus the harness-identity
+        headers OpenAI's Codex endpoint requires.  Every other provider keeps
+        the historical static-API-key behavior.
+        """
+        if not self._codex_oauth_enabled():
+            if self.config.llm_api_key:
+                return {"Authorization": f"Bearer {self.config.llm_api_key}"}
+            return {}
+
+        from . import codex_oauth
+
+        try:
+            return codex_oauth.build_auth_headers(api_base)
+        except codex_oauth.CodexAuthError as e:
+            detail = f"Codex OAuth auth failed: {e}"
+            if getattr(e, "relogin_required", False):
+                detail += " — run `hermes auth` (or `codex`) to re-authenticate."
+            logger.error("[CodexOAuth] %s", detail)
+            raise HTTPException(status_code=401, detail=detail) from e
+
     def _prepare_responses_forward(
         self,
         body: dict[str, Any],
@@ -2581,9 +2609,7 @@ class SkillClawAPIServer:
         send_body["model"] = self.config.llm_model_id or body.get("model", "")
         send_body["stream"] = stream
 
-        headers: dict[str, str] = {}
-        if self.config.llm_api_key:
-            headers["Authorization"] = f"Bearer {self.config.llm_api_key}"
+        headers = self._build_upstream_auth_headers(api_base)
         return f"{api_base}/responses", send_body, headers
 
     def _prepare_native_responses_body(self, body: dict[str, Any], *, turn_type: str) -> dict[str, Any]:
@@ -2868,6 +2894,142 @@ class SkillClawAPIServer:
             logger.error("[OpenClaw] Responses stream failed: %s", e, exc_info=True)
             raise HTTPException(status_code=502, detail=f"Responses stream error: {e}") from e
 
+    def _chat_body_to_responses(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Translate an OpenAI chat-completions body into a Responses body.
+
+        Used when a chat-only client (e.g. the evolve server's ``AsyncLLMClient``)
+        talks to a proxy whose upstream exposes ONLY ``/responses`` -- notably the
+        Codex backend under ``codex_oauth``.  System/developer messages become
+        ``instructions``; the remaining turns become typed ``input`` items.
+        """
+        instructions: list[str] = []
+        input_items: list[dict[str, Any]] = []
+
+        for message in body.get("messages") or []:
+            if not isinstance(message, dict):
+                continue
+            role = str(message.get("role") or "user")
+            content = message.get("content")
+            if isinstance(content, list):
+                text = "".join(
+                    str(part.get("text") or "")
+                    for part in content
+                    if isinstance(part, dict) and part.get("type") in {"text", "input_text", "output_text"}
+                )
+            else:
+                text = str(content or "")
+            if not text:
+                continue
+            if role in {"system", "developer"}:
+                instructions.append(text)
+                continue
+            # Responses uses input_text for user turns and output_text for
+            # assistant turns; mixing them up is a 400 from the backend.
+            part_type = "output_text" if role == "assistant" else "input_text"
+            input_items.append({"type": "message", "role": role, "content": [{"type": part_type, "text": text}]})
+
+        send_body: dict[str, Any] = {
+            "model": self.config.llm_model_id or body.get("model", ""),
+            "input": input_items,
+            "stream": False,
+            "store": False,
+        }
+        if instructions:
+            send_body["instructions"] = "\n\n".join(instructions)
+        # NOTE: deliberately no max_output_tokens / temperature passthrough.
+        # The Codex backend rejects both ("Unsupported parameter"), and chat
+        # clients routinely set them, so silently dropping is the only way the
+        # bridge stays usable.
+        return send_body
+
+    @staticmethod
+    def _responses_payload_to_chat(payload: dict[str, Any], model: str) -> dict[str, Any]:
+        """Render a Responses payload in chat-completions shape for chat clients."""
+        text_parts: list[str] = []
+        for item in payload.get("output") or []:
+            if not isinstance(item, dict) or item.get("type") != "message":
+                continue
+            for part in item.get("content") or []:
+                if isinstance(part, dict) and part.get("type") == "output_text":
+                    text_parts.append(str(part.get("text") or ""))
+        usage = payload.get("usage") if isinstance(payload.get("usage"), dict) else {}
+        return {
+            "id": payload.get("id", "chatcmpl-skillclaw"),
+            "object": "chat.completion",
+            "created": payload.get("created_at", 0),
+            "model": payload.get("model", model),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "".join(text_parts)},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": usage.get("input_tokens", 0),
+                "completion_tokens": usage.get("output_tokens", 0),
+                "total_tokens": usage.get("total_tokens", 0),
+            },
+        }
+
+    async def _forward_chat_via_responses(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Serve a chat-completions request from a Responses-only upstream.
+
+        The Codex backend rejects non-streaming Responses calls outright
+        ("Stream must be set to true"), so the bridge always streams and
+        aggregates the SSE events back into a single chat-shaped payload.
+        """
+        import httpx
+
+        api_base = self.config.llm_api_base.rstrip("/")
+        send_body = self._chat_body_to_responses(body)
+        send_body["stream"] = True
+        headers = self._build_upstream_auth_headers(api_base)
+
+        final_payload: dict[str, Any] = {}
+        text_parts: list[str] = []
+        try:
+            async with httpx.AsyncClient(timeout=_llm_request_timeout_seconds()) as client:
+                async with client.stream("POST", f"{api_base}/responses", json=send_body, headers=headers) as resp:
+                    if resp.status_code >= 400:
+                        # Must be read inside the stream context; the body is
+                        # otherwise unavailable once the response closes.
+                        detail = (await resp.aread()).decode("utf-8", "ignore")[:300]
+                        logger.error("[SkillClaw] chat→responses bridge error: %s %s", resp.status_code, detail)
+                        raise HTTPException(
+                            status_code=502, detail=f"Upstream Responses error {resp.status_code}: {detail}"
+                        )
+                    async for line in resp.aiter_lines():
+                        stripped = line.strip()
+                        if not stripped.startswith("data: "):
+                            continue
+                        raw = stripped[6:]
+                        if raw == "[DONE]":
+                            break
+                        try:
+                            event = json.loads(raw)
+                        except Exception:
+                            continue
+                        etype = event.get("type")
+                        if etype == "response.output_text.delta":
+                            text_parts.append(str(event.get("delta") or ""))
+                        elif etype == "response.completed":
+                            candidate = event.get("response")
+                            if isinstance(candidate, dict):
+                                final_payload = candidate
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error("[SkillClaw] chat→responses bridge failed: %s", e, exc_info=True)
+            raise HTTPException(status_code=502, detail=f"Responses bridge error: {e}") from e
+
+        chat = self._responses_payload_to_chat(final_payload, send_body.get("model", ""))
+        # Prefer the streamed deltas: response.completed occasionally omits the
+        # assembled output, which would otherwise yield an empty message.
+        if not chat["choices"][0]["message"]["content"] and text_parts:
+            chat["choices"][0]["message"]["content"] = "".join(text_parts)
+        return chat
+
     async def _forward_to_llm_openai(self, body: dict[str, Any]) -> dict[str, Any]:
         """Forward to an OpenAI-compatible API."""
         import httpx
@@ -2879,14 +3041,18 @@ class SkillClawAPIServer:
                 detail="llm_api_base is not configured. Run 'skillclaw setup' first.",
             )
 
+        # A Responses-only upstream (the Codex backend) has no
+        # /chat/completions route, so chat-shaped callers must be bridged
+        # rather than forwarded verbatim into a guaranteed 404.
+        if self._responses_native_enabled():
+            return await self._forward_chat_via_responses(body)
+
         # Strip Tinker-specific fields not supported by standard OpenAI APIs
         send_body = {k: v for k, v in body.items() if k not in {"logprobs", "top_logprobs", "stream_options"}}
         send_body["model"] = self.config.llm_model_id or body.get("model", "")
         send_body["stream"] = False
 
-        headers: dict[str, str] = {}
-        if self.config.llm_api_key:
-            headers["Authorization"] = f"Bearer {self.config.llm_api_key}"
+        headers = self._build_upstream_auth_headers(api_base)
 
         # OpenRouter-specific headers and body extensions
         if self.config.llm_provider == "openrouter":

--- a/skillclaw/claw_adapter.py
+++ b/skillclaw/claw_adapter.py
@@ -42,6 +42,11 @@ logger = logging.getLogger(__name__)
 _LEGACY_SKILLCLAW_SKILLS_DIR = Path.home() / ".skillclaw" / "skills"
 _HERMES_HOME = Path.home() / ".hermes"
 _HERMES_SKILLS_DIR = _HERMES_HOME / "skills"
+# Named provider entry registered in Hermes' ``providers:`` map when SkillClaw
+# forwards to a Responses-only upstream. Hermes honours a NAMED provider's
+# transport verbatim, whereas a bare ``provider: custom`` has its
+# ``codex_responses`` mode stripped for non-OpenAI hosts.
+_HERMES_PROVIDER_NAME = "skillclaw"
 _HERMES_BACKUP_DIR = Path.home() / ".skillclaw" / "backups" / "hermes"
 _CODEX_HOME = Path.home() / ".codex"
 _CODEX_CONFIG_PATH = _CODEX_HOME / "config.toml"
@@ -482,12 +487,40 @@ def _configure_hermes(cfg: "SkillClawConfig") -> None:
     if not isinstance(model, dict):
         model = {"default": model} if isinstance(model, str) and model.strip() else {}
 
-    model["provider"] = "custom"
+    responses_mode = str(getattr(cfg, "llm_api_mode", "") or "").strip().lower() == "responses"
+
+    if responses_mode:
+        # SkillClaw is forwarding to a Responses-only backend (the Codex
+        # endpoint under ``codex_oauth``), so the proxy exposes /v1/responses
+        # but NOT /v1/chat/completions.
+        #
+        # Hermes deliberately *discards* ``api_mode: codex_responses`` for a
+        # bare ``provider: custom`` pointed at a non-OpenAI host (see
+        # hermes_cli/runtime_provider.py::_resolve_plain_custom_api_mode) as a
+        # guard against stale config. A NAMED custom provider is the supported
+        # opt-in: its ``transport`` is honoured verbatim. Register one so the
+        # Responses wire survives, instead of silently falling back to chat
+        # completions and 404-ing against the proxy.
+        providers = data.get("providers")
+        if not isinstance(providers, dict):
+            providers = {}
+        providers[_HERMES_PROVIDER_NAME] = {
+            "name": "SkillClaw",
+            "base_url": base_url,
+            "api_key": api_key,
+            "transport": "codex_responses",
+        }
+        data["providers"] = providers
+        model["provider"] = _HERMES_PROVIDER_NAME
+        model["api_mode"] = "codex_responses"
+    else:
+        model["provider"] = "custom"
+        # Clear stale provider-specific mode so Hermes auto-detects from the URL.
+        model["api_mode"] = ""
+
     model["base_url"] = base_url
     model["default"] = model_id
     model["api_key"] = api_key
-    # Clear stale provider-specific mode so Hermes auto-detects from the proxy URL.
-    model["api_mode"] = ""
 
     data["model"] = model
     _backup_hermes_config_if_changed(config_path, _yaml_mapping_to_text(data))
@@ -513,8 +546,12 @@ def inspect_hermes_config(cfg: "SkillClawConfig") -> dict[str, object]:
     configured_api_key = str(model.get("api_key", "") or "")
 
     backup_path = _latest_hermes_backup_path()
+    # Either wiring is valid: a bare ``custom`` provider for chat-completions
+    # upstreams, or the named ``skillclaw`` provider used when the upstream is
+    # Responses-only (see _configure_hermes for why the named entry is
+    # required there).
     proxy_match = (
-        configured_provider == "custom"
+        configured_provider in {"custom", _HERMES_PROVIDER_NAME}
         and configured_base_url == expected_base_url
         and configured_default == expected_model
         and configured_api_key == expected_api_key

--- a/skillclaw/codex_oauth.py
+++ b/skillclaw/codex_oauth.py
@@ -1,0 +1,511 @@
+"""Codex (ChatGPT-account) OAuth credential bridge for SkillClaw.
+
+SkillClaw's stock forwarding path sends a *static* ``Authorization: Bearer
+<api_key>`` taken from ``~/.skillclaw/config.yaml``.  That model does not fit
+OpenAI's ``chatgpt.com/backend-api/codex`` endpoint, which authenticates with a
+short-lived OAuth access token issued against a ChatGPT (Plus/Pro) account and
+additionally requires harness-identity headers.
+
+This module supplies both, reusing the credentials that Hermes / the Codex CLI
+already maintain on disk.
+
+Design notes
+------------
+*Piggyback, don't compete.*  Codex OAuth ``refresh_token``s are **single-use**:
+whoever redeems one invalidates every other copy.  Hermes is the active agent on
+this machine and refreshes on its own schedule, so SkillClaw deliberately does
+NOT refresh on a timer.  It re-reads the token store on every request and uses
+whatever Hermes most recently wrote.  Only when the on-disk access token is
+genuinely expired (and Hermes has not yet rotated it) does SkillClaw perform a
+refresh itself -- and then it writes the result back to *both* stores so Hermes
+and the Codex CLI stay in sync instead of being stranded on a consumed token.
+
+Token store precedence mirrors Hermes' own recovery order:
+1. ``~/.hermes/auth.json``  -> ``providers.openai-codex.tokens``
+2. ``~/.codex/auth.json``   -> ``tokens``          (Codex CLI shared file)
+
+The newest valid access token across both wins.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# OAuth client identity, mirrored from Hermes (hermes_cli/auth.py).
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+
+# Refresh this many seconds before the JWT's own ``exp``.  Matches Hermes'
+# CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS so both agents consider a token
+# "stale" at the same moment rather than fighting over a narrow window.
+REFRESH_SKEW_SECONDS = 120
+
+_HERMES_AUTH_PATH = Path.home() / ".hermes" / "auth.json"
+
+# Serialises refreshes within this process.  Cross-process races are handled by
+# re-reading the store after acquiring the lock (another agent may have already
+# rotated the token while we waited).
+_refresh_lock = threading.Lock()
+
+
+# --------------------------------------------------------------------------- #
+# Path helpers                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _codex_auth_path() -> Path:
+    """Return ~/.codex/auth.json, honouring CODEX_HOME like the Codex CLI."""
+    codex_home = os.getenv("CODEX_HOME", "").strip()
+    if not codex_home:
+        codex_home = str(Path.home() / ".codex")
+    return Path(codex_home).expanduser() / "auth.json"
+
+
+# --------------------------------------------------------------------------- #
+# JWT inspection                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def decode_jwt_claims(token: str) -> dict[str, Any]:
+    """Best-effort decode of a JWT payload. Returns {} on any malformed input.
+
+    Never raises: a bad token should surface downstream as a 401 from the API,
+    not as a crash inside SkillClaw's request path.
+    """
+    if not isinstance(token, str) or not token.strip():
+        return {}
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return {}
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return claims if isinstance(claims, dict) else {}
+    except Exception:
+        return {}
+
+
+def token_expiry(token: str) -> float | None:
+    """Return the JWT ``exp`` as a unix timestamp, or None if absent."""
+    exp = decode_jwt_claims(token).get("exp")
+    if isinstance(exp, (int, float)):
+        return float(exp)
+    return None
+
+
+def is_expired(token: str, *, skew_seconds: float = REFRESH_SKEW_SECONDS) -> bool:
+    """True when the token is past (exp - skew).
+
+    A token with no parseable ``exp`` is treated as still valid: we would rather
+    let the upstream reject it than trigger an unnecessary refresh that consumes
+    the single-use refresh token.
+    """
+    exp = token_expiry(token)
+    if exp is None:
+        return False
+    return time.time() >= (exp - float(skew_seconds))
+
+
+def account_id_from_token(token: str) -> str:
+    """Extract the ChatGPT account id claim used for the account header."""
+    claims = decode_jwt_claims(token)
+    auth_claims = claims.get("https://api.openai.com/auth")
+    if isinstance(auth_claims, dict):
+        acct = auth_claims.get("chatgpt_account_id")
+        if isinstance(acct, str) and acct.strip():
+            return acct.strip()
+    return ""
+
+
+# --------------------------------------------------------------------------- #
+# Token store reads                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        if not path.is_file():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+        return data if isinstance(data, dict) else {}
+    except Exception as e:
+        logger.debug("[CodexOAuth] could not read %s: %s", path, e)
+        return {}
+
+
+def _tokens_from_hermes_store() -> dict[str, str]:
+    payload = _read_json(_HERMES_AUTH_PATH)
+    providers = payload.get("providers")
+    if not isinstance(providers, dict):
+        return {}
+    entry = providers.get("openai-codex")
+    if not isinstance(entry, dict):
+        return {}
+    tokens = entry.get("tokens")
+    if not isinstance(tokens, dict):
+        return {}
+    return {
+        "access_token": str(tokens.get("access_token", "") or ""),
+        "refresh_token": str(tokens.get("refresh_token", "") or ""),
+        "account_id": str(tokens.get("account_id", "") or ""),
+    }
+
+
+def _tokens_from_codex_cli_store() -> dict[str, str]:
+    payload = _read_json(_codex_auth_path())
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        return {}
+    return {
+        "access_token": str(tokens.get("access_token", "") or ""),
+        "refresh_token": str(tokens.get("refresh_token", "") or ""),
+        "account_id": str(tokens.get("account_id", "") or ""),
+    }
+
+
+def load_tokens() -> dict[str, str]:
+    """Load the freshest Codex token pair available on this machine.
+
+    Prefers whichever store holds the access token with the later ``exp`` so we
+    naturally adopt a rotation performed by Hermes or the Codex CLI.
+    """
+    candidates = [t for t in (_tokens_from_hermes_store(), _tokens_from_codex_cli_store()) if t.get("access_token")]
+    if not candidates:
+        return {}
+    if len(candidates) == 1:
+        return candidates[0]
+
+    def sort_key(tok: dict[str, str]) -> float:
+        exp = token_expiry(tok.get("access_token", ""))
+        return exp if exp is not None else 0.0
+
+    return max(candidates, key=sort_key)
+
+
+# --------------------------------------------------------------------------- #
+# Token store writes                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON via a temp file + rename so readers never see a partial file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".skillclaw.tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except Exception:
+        pass
+    os.replace(tmp, path)
+
+
+def _persist_to_hermes_store(tokens: dict[str, str], last_refresh: str) -> bool:
+    """Update providers.openai-codex in ~/.hermes/auth.json, preserving the rest.
+
+    Also refreshes any credential_pool entries that carried the *previous*
+    access/refresh pair, mirroring Hermes' own singleton->pool sync so the pool
+    does not keep replaying a token we have just consumed.
+    """
+    payload = _read_json(_HERMES_AUTH_PATH)
+    if not payload:
+        return False
+    providers = payload.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        return False
+    entry = providers.get("openai-codex")
+    if not isinstance(entry, dict):
+        entry = {}
+    stale = entry.get("tokens") if isinstance(entry.get("tokens"), dict) else {}
+    stale_access = str(stale.get("access_token", "") or "")
+    stale_refresh = str(stale.get("refresh_token", "") or "")
+
+    merged = dict(stale)
+    merged.update(
+        {
+            "access_token": tokens["access_token"],
+            "refresh_token": tokens["refresh_token"],
+        }
+    )
+    entry["tokens"] = merged
+    entry["last_refresh"] = last_refresh
+    entry.setdefault("auth_mode", "chatgpt")
+    providers["openai-codex"] = entry
+
+    pool = payload.get("credential_pool")
+    if isinstance(pool, dict):
+        codex_entries = pool.get("openai-codex")
+        if isinstance(codex_entries, list):
+            for pool_entry in codex_entries:
+                if not isinstance(pool_entry, dict):
+                    continue
+                # Only advance entries that were aliases of the singleton we
+                # just rotated; independent accounts keep their own tokens.
+                if (
+                    str(pool_entry.get("access_token", "") or "") == stale_access
+                    or str(pool_entry.get("refresh_token", "") or "") == stale_refresh
+                ):
+                    pool_entry["access_token"] = tokens["access_token"]
+                    pool_entry["refresh_token"] = tokens["refresh_token"]
+                    pool_entry["last_refresh"] = last_refresh
+
+    _write_json_atomic(_HERMES_AUTH_PATH, payload)
+    return True
+
+
+def _persist_to_codex_cli_store(tokens: dict[str, str], last_refresh: str) -> bool:
+    """Update ~/.codex/auth.json so the Codex CLI does not strand on a dead token."""
+    path = _codex_auth_path()
+    payload = _read_json(path)
+    if not payload:
+        return False
+    existing = payload.get("tokens") if isinstance(payload.get("tokens"), dict) else {}
+    merged = dict(existing)
+    merged.update(
+        {
+            "access_token": tokens["access_token"],
+            "refresh_token": tokens["refresh_token"],
+        }
+    )
+    payload["tokens"] = merged
+    payload["last_refresh"] = last_refresh
+    _write_json_atomic(path, payload)
+    return True
+
+
+def persist_tokens(tokens: dict[str, str]) -> list[str]:
+    """Write a refreshed pair to every store that already tracked Codex auth.
+
+    Returns the list of store paths successfully updated.  Stores that do not
+    exist are skipped rather than created -- SkillClaw should never invent a
+    credential file for a tool the user does not use.
+    """
+    from datetime import datetime, timezone
+
+    last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    written: list[str] = []
+    for label, path, fn in (
+        ("hermes", _HERMES_AUTH_PATH, _persist_to_hermes_store),
+        ("codex-cli", _codex_auth_path(), _persist_to_codex_cli_store),
+    ):
+        try:
+            if fn(tokens, last_refresh):
+                written.append(str(path))
+        except Exception as e:
+            logger.warning("[CodexOAuth] failed to persist tokens to %s store (%s): %s", label, path, e)
+    return written
+
+
+# --------------------------------------------------------------------------- #
+# Refresh                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+class CodexAuthError(RuntimeError):
+    """Raised when a usable Codex OAuth access token cannot be obtained."""
+
+    def __init__(self, message: str, *, code: str = "codex_auth_error", relogin_required: bool = False):
+        super().__init__(message)
+        self.code = code
+        self.relogin_required = relogin_required
+
+
+def refresh_tokens(refresh_token: str, *, timeout_seconds: float = 20.0) -> dict[str, str]:
+    """Redeem a refresh token for a new access token.
+
+    Pure with respect to local state: the caller decides whether to persist.
+    """
+    import httpx
+
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        raise CodexAuthError(
+            "Codex auth is missing refresh_token; run `hermes auth` to re-authenticate.",
+            code="codex_auth_missing_refresh_token",
+            relogin_required=True,
+        )
+
+    with httpx.Client(timeout=httpx.Timeout(max(5.0, float(timeout_seconds)))) as client:
+        response = client.post(
+            CODEX_OAUTH_TOKEN_URL,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+                "User-Agent": "skillclaw-codex-oauth",
+            },
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token.strip(),
+                "client_id": CODEX_OAUTH_CLIENT_ID,
+            },
+        )
+
+    if response.status_code == 429:
+        # Quota exhaustion, not a credential problem -- the stored refresh token
+        # is still good, so never escalate this to "please re-login".
+        raise CodexAuthError(
+            "Codex provider quota exhausted (429); credentials are still valid.",
+            code="codex_rate_limited",
+            relogin_required=False,
+        )
+
+    if response.status_code != 200:
+        code = "codex_refresh_failed"
+        message = f"Codex token refresh failed with status {response.status_code}."
+        try:
+            err = response.json()
+            if isinstance(err, dict):
+                err_obj = err.get("error")
+                if isinstance(err_obj, dict):
+                    code = str(err_obj.get("code") or err_obj.get("type") or code)
+                    if err_obj.get("message"):
+                        message = f"Codex token refresh failed: {err_obj['message']}"
+                elif isinstance(err_obj, str) and err_obj.strip():
+                    code = err_obj.strip()
+                    desc = err.get("error_description") or err.get("message")
+                    if desc:
+                        message = f"Codex token refresh failed: {desc}"
+        except Exception:
+            pass
+        relogin = code in {"invalid_grant", "invalid_token", "invalid_request", "refresh_token_reused"} or (
+            response.status_code in {401, 403}
+        )
+        if code == "refresh_token_reused":
+            message = (
+                "Codex refresh token was already consumed by another client "
+                "(Hermes, Codex CLI, or the VS Code extension). "
+                "Run `codex` then `hermes auth` to mint a fresh pair."
+            )
+        raise CodexAuthError(message, code=code, relogin_required=relogin)
+
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise CodexAuthError(
+            "Codex token refresh returned invalid JSON.",
+            code="codex_refresh_invalid_json",
+            relogin_required=True,
+        ) from exc
+
+    access = payload.get("access_token")
+    if not isinstance(access, str) or not access.strip():
+        raise CodexAuthError(
+            "Codex token refresh response was missing access_token.",
+            code="codex_refresh_missing_access_token",
+            relogin_required=True,
+        )
+
+    rotated = payload.get("refresh_token")
+    return {
+        "access_token": access.strip(),
+        "refresh_token": (rotated.strip() if isinstance(rotated, str) and rotated.strip() else refresh_token.strip()),
+    }
+
+
+def get_access_token(*, allow_refresh: bool = True) -> str:
+    """Return a currently-valid Codex access token.
+
+    Re-reads the shared token stores on every call so a rotation performed by
+    Hermes is picked up immediately and no refresh is spent unnecessarily.
+    """
+    tokens = load_tokens()
+    if not tokens.get("access_token"):
+        raise CodexAuthError(
+            "No Codex OAuth tokens found. Log in with `hermes auth` (or run `codex`) first.",
+            code="codex_auth_missing",
+            relogin_required=True,
+        )
+
+    if not is_expired(tokens["access_token"]):
+        return tokens["access_token"]
+
+    if not allow_refresh:
+        raise CodexAuthError(
+            "Codex access token is expired and refresh is disabled.",
+            code="codex_auth_expired",
+            relogin_required=False,
+        )
+
+    with _refresh_lock:
+        # Another process (usually Hermes itself) may have rotated the token
+        # while we waited for the lock -- prefer their work over spending our
+        # single-use refresh token.
+        latest = load_tokens()
+        if latest.get("access_token") and not is_expired(latest["access_token"]):
+            return latest["access_token"]
+
+        refreshed = refresh_tokens(latest.get("refresh_token") or tokens.get("refresh_token", ""))
+        written = persist_tokens(refreshed)
+        logger.info(
+            "[CodexOAuth] refreshed Codex access token; synced %d store(s): %s",
+            len(written),
+            ", ".join(written) or "(none)",
+        )
+        return refreshed["access_token"]
+
+
+# --------------------------------------------------------------------------- #
+# Request headers                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def is_codex_base_url(base_url: str) -> bool:
+    """True only for OpenAI's official Codex endpoint (not look-alike proxies)."""
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(base_url or "")
+        path = parsed.path.rstrip("/")
+        return (
+            parsed.scheme == "https"
+            and parsed.hostname == "chatgpt.com"
+            and parsed.port in (None, 443)
+            and (path == "/backend-api/codex" or path.startswith("/backend-api/codex/"))
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+def build_auth_headers(base_url: str, *, allow_refresh: bool = True) -> dict[str, str]:
+    """Authorization + harness-identity headers for a Codex OAuth request.
+
+    OpenAI requires third-party harnesses to identify themselves via
+    ``originator`` / ``User-Agent``, and to pass the account id from the token's
+    ``chatgpt_account_id`` claim.  Without these the endpoint rejects the call.
+    """
+    access_token = get_access_token(allow_refresh=allow_refresh)
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "User-Agent": "codex_cli_rs/0.0.0 (SkillClaw)",
+        "originator": "codex_cli_rs",
+    }
+    account_id = account_id_from_token(access_token)
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+    return headers
+
+
+def describe() -> dict[str, Any]:
+    """Diagnostic snapshot for `skillclaw doctor` / manual troubleshooting."""
+    tokens = load_tokens()
+    access = tokens.get("access_token", "")
+    exp = token_expiry(access)
+    return {
+        "hermes_store": str(_HERMES_AUTH_PATH),
+        "hermes_store_present": _HERMES_AUTH_PATH.is_file(),
+        "codex_cli_store": str(_codex_auth_path()),
+        "codex_cli_store_present": _codex_auth_path().is_file(),
+        "access_token_present": bool(access),
+        "access_token_expired": is_expired(access) if access else None,
+        "expires_at_unix": exp,
+        "expires_in_seconds": (round(exp - time.time()) if exp else None),
+        "account_id": account_id_from_token(access) if access else "",
+        "refresh_token_present": bool(tokens.get("refresh_token")),
+    }

--- a/skillclaw/config.py
+++ b/skillclaw/config.py
@@ -64,6 +64,10 @@ class SkillClawConfig:
     # ------------------------------------------------------------------ #
     # LLM forwarding                                                      #
     # ------------------------------------------------------------------ #
+    # ``"codex_oauth"`` authenticates with the ChatGPT-account OAuth token that
+    # Hermes / the Codex CLI already maintain on disk instead of a static API
+    # key, so a ChatGPT Plus/Pro subscription can be used without provisioning
+    # separate pay-per-token API billing. See skillclaw/codex_oauth.py.
     llm_provider: str = "openai"
     llm_api_base: str = ""
     llm_api_key: str = ""

--- a/skillclaw/setup_wizard.py
+++ b/skillclaw/setup_wizard.py
@@ -43,6 +43,10 @@ _PROVIDER_PRESETS = {
         "api_base": "https://api.atlascloud.ai/v1",
         "model_id": "deepseek-ai/DeepSeek-V3.1",
     },
+    "codex_oauth": {
+        "api_base": "https://chatgpt.com/backend-api/codex",
+        "model_id": "gpt-5.6-terra",
+    },
     "bedrock": {
         "api_base": "",
         "model_id": "us.anthropic.claude-sonnet-4-6",
@@ -52,9 +56,22 @@ _PROVIDER_PRESETS = {
         "model_id": "",
     },
 }
-_PROVIDER_CHOICES = ["kimi", "qwen", "openai", "minimax", "novita", "openrouter", "atlascloud", "bedrock", "custom"]
+_PROVIDER_CHOICES = [
+    "kimi",
+    "qwen",
+    "openai",
+    "minimax",
+    "novita",
+    "openrouter",
+    "atlascloud",
+    "codex_oauth",
+    "bedrock",
+    "custom",
+]
 _PROVIDER_DEFAULT_API_MODE = {
     "atlascloud": "chat",
+    # The Codex backend speaks the Responses API, not chat-completions.
+    "codex_oauth": "responses",
 }
 
 
@@ -187,11 +204,22 @@ class SetupWizard:
                 "Model ID",
                 default=(current_llm.get("model_id") if provider_unchanged else "") or preset["model_id"],
             )
-            api_key = _prompt(
-                "API key",
-                default=current_llm.get("api_key", "") if provider_unchanged else "",
-                hide=True,
-            )
+            if provider == "codex_oauth":
+                # Auth comes from the on-disk ChatGPT OAuth token maintained by
+                # Hermes / the Codex CLI, so there is no static key to collect.
+                api_key = ""
+                print(
+                    "\nUsing ChatGPT-account OAuth credentials from\n"
+                    "  ~/.hermes/auth.json  (or ~/.codex/auth.json)\n"
+                    "No API key needed — your ChatGPT subscription is used, not pay-per-token API billing.\n"
+                    "Log in first with `hermes auth` (or run `codex`) if you have not already."
+                )
+            else:
+                api_key = _prompt(
+                    "API key",
+                    default=current_llm.get("api_key", "") if provider_unchanged else "",
+                    hide=True,
+                )
 
         # OpenRouter-specific options
         if provider == "openrouter":

--- a/tests/test_codex_oauth.py
+++ b/tests/test_codex_oauth.py
@@ -1,0 +1,254 @@
+"""Tests for the Codex (ChatGPT-account) OAuth credential bridge."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import pytest
+
+from skillclaw import codex_oauth
+
+
+def _make_jwt(claims: dict) -> str:
+    """Build an unsigned JWT whose payload carries *claims*."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"{header}.{payload}.sig"
+
+
+def _token(*, exp_offset: float = 3600.0, account_id: str = "acct-123") -> str:
+    return _make_jwt(
+        {
+            "exp": time.time() + exp_offset,
+            "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+        }
+    )
+
+
+# --------------------------------------------------------------------------- #
+# JWT parsing                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_decode_jwt_claims_reads_payload():
+    token = _make_jwt({"hello": "world"})
+    assert codex_oauth.decode_jwt_claims(token)["hello"] == "world"
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-jwt", "only.two", None, 12345])
+def test_decode_jwt_claims_tolerates_garbage(bad):
+    """Malformed tokens must never raise -- they should 401 upstream instead."""
+    assert codex_oauth.decode_jwt_claims(bad) == {}
+
+
+def test_account_id_extracted_from_auth_claim():
+    assert codex_oauth.account_id_from_token(_token(account_id="acct-xyz")) == "acct-xyz"
+
+
+def test_account_id_missing_claim_returns_empty():
+    assert codex_oauth.account_id_from_token(_make_jwt({"exp": 1})) == ""
+
+
+# --------------------------------------------------------------------------- #
+# Expiry                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_fresh_token_is_not_expired():
+    assert codex_oauth.is_expired(_token(exp_offset=3600)) is False
+
+
+def test_past_exp_is_expired():
+    assert codex_oauth.is_expired(_token(exp_offset=-10)) is True
+
+
+def test_within_skew_window_is_expired():
+    """A token expiring inside the skew window is refreshed proactively."""
+    assert codex_oauth.is_expired(_token(exp_offset=30), skew_seconds=120) is True
+
+
+def test_token_without_exp_is_treated_as_valid():
+    """No parseable exp must NOT burn the single-use refresh token."""
+    assert codex_oauth.is_expired(_make_jwt({"foo": "bar"})) is False
+
+
+# --------------------------------------------------------------------------- #
+# Base URL guard                                                               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://chatgpt.com/backend-api/codex", True),
+        ("https://chatgpt.com/backend-api/codex/", True),
+        ("https://chatgpt.com/backend-api/codex/responses", True),
+        # Look-alikes and downgrades must all be rejected.
+        ("http://chatgpt.com/backend-api/codex", False),
+        ("https://chatgpt.com.attacker.test/backend-api/codex", False),
+        ("https://evil.test/chatgpt.com/backend-api/codex", False),
+        ("https://api.openai.com/v1", False),
+        ("", False),
+    ],
+)
+def test_is_codex_base_url(url, expected):
+    assert codex_oauth.is_codex_base_url(url) is expected
+
+
+# --------------------------------------------------------------------------- #
+# Token store resolution                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_load_tokens_prefers_later_expiry(monkeypatch, tmp_path):
+    """A rotation written by another agent should win automatically."""
+    stale, fresh = _token(exp_offset=60), _token(exp_offset=9999)
+
+    hermes = tmp_path / "hermes-auth.json"
+    hermes.write_text(
+        json.dumps({"providers": {"openai-codex": {"tokens": {"access_token": stale, "refresh_token": "r-old"}}}})
+    )
+    codex = tmp_path / "codex-auth.json"
+    codex.write_text(json.dumps({"tokens": {"access_token": fresh, "refresh_token": "r-new"}}))
+
+    monkeypatch.setattr(codex_oauth, "_HERMES_AUTH_PATH", hermes)
+    monkeypatch.setattr(codex_oauth, "_codex_auth_path", lambda: codex)
+
+    assert codex_oauth.load_tokens()["access_token"] == fresh
+
+
+def test_load_tokens_empty_when_no_stores(monkeypatch, tmp_path):
+    monkeypatch.setattr(codex_oauth, "_HERMES_AUTH_PATH", tmp_path / "nope.json")
+    monkeypatch.setattr(codex_oauth, "_codex_auth_path", lambda: tmp_path / "also-nope.json")
+    assert codex_oauth.load_tokens() == {}
+
+
+def test_get_access_token_raises_when_unauthenticated(monkeypatch, tmp_path):
+    monkeypatch.setattr(codex_oauth, "_HERMES_AUTH_PATH", tmp_path / "nope.json")
+    monkeypatch.setattr(codex_oauth, "_codex_auth_path", lambda: tmp_path / "also-nope.json")
+    with pytest.raises(codex_oauth.CodexAuthError) as exc:
+        codex_oauth.get_access_token()
+    assert exc.value.relogin_required is True
+
+
+def test_valid_token_is_returned_without_refresh(monkeypatch, tmp_path):
+    """The happy path must not touch the network or spend the refresh token."""
+    good = _token(exp_offset=9999)
+    hermes = tmp_path / "hermes-auth.json"
+    hermes.write_text(
+        json.dumps({"providers": {"openai-codex": {"tokens": {"access_token": good, "refresh_token": "r"}}}})
+    )
+    monkeypatch.setattr(codex_oauth, "_HERMES_AUTH_PATH", hermes)
+    monkeypatch.setattr(codex_oauth, "_codex_auth_path", lambda: tmp_path / "absent.json")
+
+    def _boom(*a, **k):
+        raise AssertionError("refresh must not be called for a valid token")
+
+    monkeypatch.setattr(codex_oauth, "refresh_tokens", _boom)
+    assert codex_oauth.get_access_token() == good
+
+
+def test_expired_token_triggers_refresh_and_persists(monkeypatch, tmp_path):
+    expired, renewed = _token(exp_offset=-100), _token(exp_offset=9999)
+
+    hermes = tmp_path / "hermes-auth.json"
+    hermes.write_text(
+        json.dumps(
+            {
+                "providers": {"openai-codex": {"tokens": {"access_token": expired, "refresh_token": "r-old"}}},
+                "credential_pool": {"openai-codex": [{"id": "a", "access_token": expired, "refresh_token": "r-old"}]},
+            }
+        )
+    )
+    codex = tmp_path / "codex-auth.json"
+    codex.write_text(
+        json.dumps({"auth_mode": "chatgpt", "tokens": {"access_token": expired, "refresh_token": "r-old"}})
+    )
+
+    monkeypatch.setattr(codex_oauth, "_HERMES_AUTH_PATH", hermes)
+    monkeypatch.setattr(codex_oauth, "_codex_auth_path", lambda: codex)
+    monkeypatch.setattr(
+        codex_oauth,
+        "refresh_tokens",
+        lambda rt, **k: {"access_token": renewed, "refresh_token": "r-new"},
+    )
+
+    assert codex_oauth.get_access_token() == renewed
+
+    # Both stores advance, so neither Hermes nor the Codex CLI is stranded on
+    # a refresh token we just consumed.
+    h = json.loads(hermes.read_text())
+    assert h["providers"]["openai-codex"]["tokens"]["access_token"] == renewed
+    assert h["providers"]["openai-codex"]["tokens"]["refresh_token"] == "r-new"
+    assert h["credential_pool"]["openai-codex"][0]["refresh_token"] == "r-new"
+
+    c = json.loads(codex.read_text())
+    assert c["tokens"]["access_token"] == renewed
+    # Unrelated fields survive the rewrite.
+    assert c["auth_mode"] == "chatgpt"
+
+
+def test_persist_skips_absent_stores(monkeypatch, tmp_path):
+    """SkillClaw must not invent a credential file for a tool you don't use."""
+    hermes = tmp_path / "hermes-auth.json"
+    hermes.write_text(json.dumps({"providers": {"openai-codex": {"tokens": {}}}}))
+    absent = tmp_path / "absent.json"
+
+    monkeypatch.setattr(codex_oauth, "_HERMES_AUTH_PATH", hermes)
+    monkeypatch.setattr(codex_oauth, "_codex_auth_path", lambda: absent)
+
+    written = codex_oauth.persist_tokens({"access_token": "a", "refresh_token": "r"})
+    assert str(hermes) in written
+    assert not absent.exists()
+
+
+def test_independent_pool_entries_are_not_overwritten(monkeypatch, tmp_path):
+    """Separate accounts in the pool keep their own credentials."""
+    expired, renewed = _token(exp_offset=-100), _token(exp_offset=9999)
+    hermes = tmp_path / "hermes-auth.json"
+    hermes.write_text(
+        json.dumps(
+            {
+                "providers": {"openai-codex": {"tokens": {"access_token": expired, "refresh_token": "r-old"}}},
+                "credential_pool": {
+                    "openai-codex": [
+                        {"id": "alias", "access_token": expired, "refresh_token": "r-old"},
+                        {"id": "other", "access_token": "other-tok", "refresh_token": "other-r"},
+                    ]
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(codex_oauth, "_HERMES_AUTH_PATH", hermes)
+    monkeypatch.setattr(codex_oauth, "_codex_auth_path", lambda: tmp_path / "absent.json")
+
+    codex_oauth.persist_tokens({"access_token": renewed, "refresh_token": "r-new"})
+
+    pool = json.loads(hermes.read_text())["credential_pool"]["openai-codex"]
+    assert pool[0]["refresh_token"] == "r-new"
+    assert pool[1]["refresh_token"] == "other-r"
+
+
+# --------------------------------------------------------------------------- #
+# Request headers                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_auth_headers_includes_identity(monkeypatch):
+    token = _token(account_id="acct-hdr")
+    monkeypatch.setattr(codex_oauth, "get_access_token", lambda **k: token)
+
+    headers = codex_oauth.build_auth_headers("https://chatgpt.com/backend-api/codex")
+    assert headers["Authorization"] == f"Bearer {token}"
+    assert headers["ChatGPT-Account-ID"] == "acct-hdr"
+    # OpenAI requires third-party harnesses to identify themselves.
+    assert headers["originator"] == "codex_cli_rs"
+    assert "SkillClaw" in headers["User-Agent"]
+
+
+def test_build_auth_headers_omits_account_when_claim_absent(monkeypatch):
+    monkeypatch.setattr(codex_oauth, "get_access_token", lambda **k: _make_jwt({"exp": time.time() + 999}))
+    headers = codex_oauth.build_auth_headers("https://chatgpt.com/backend-api/codex")
+    assert "ChatGPT-Account-ID" not in headers


### PR DESCRIPTION
## Summary

Adds a `codex_oauth` LLM provider so SkillClaw can authenticate against OpenAI's Codex backend (`chatgpt.com/backend-api/codex`) using the **ChatGPT-account OAuth token** that Hermes and the Codex CLI already maintain on disk, instead of a static API key.

**Motivation:** users on a ChatGPT Plus/Pro subscription currently can't run SkillClaw on that subscription. `skillclaw setup` requires an API key, and the Codex endpoint doesn't accept one — so the only path is provisioning a platform API key, which bills per-token *on top of* the subscription they already pay for. This closes that gap.

## What's included

**`skillclaw/codex_oauth.py`** (new) — the credential bridge.

Reads tokens from `~/.hermes/auth.json` and `~/.codex/auth.json`, preferring whichever access token expires later so a rotation performed by either tool is adopted automatically. Inspects the JWT `exp` and refreshes via `auth.openai.com` only when genuinely expired.

The important subtlety: **Codex refresh tokens are single-use.** Whoever redeems one invalidates every other copy. So this module deliberately does *not* refresh on a timer — it re-reads the stores per request, and re-checks after acquiring the refresh lock in case another process rotated while it waited. When it does refresh, it writes the new pair back to both stores (and to matching `credential_pool` aliases) so no client is left stranded on a consumed token. Independent pool accounts are left untouched.

**`skillclaw/api_server.py`** — two changes:

1. Both forwarding paths now build auth via `_build_upstream_auth_headers()`. For `codex_oauth` that attaches the bearer token plus the harness-identity headers the endpoint requires (`originator`, `User-Agent`, and `ChatGPT-Account-ID` from the token's `chatgpt_account_id` claim). All other providers keep the existing static-key behavior unchanged.

2. A **chat→Responses bridge**. The Codex backend serves only `/responses`, so chat-shaped callers — notably the evolve server's `AsyncLLMClient` — previously 404'd. The bridge maps `system`/`developer` messages to `instructions`, converts turns to typed input items (`input_text` for user, `output_text` for assistant), always streams (the backend rejects `stream=false` with "Stream must be set to true"), and re-assembles the SSE events into a chat-completions payload. `max_output_tokens` is dropped because the backend rejects it as an unsupported parameter.

**`skillclaw/claw_adapter.py`** — when the upstream is Responses-only, register a named `skillclaw` provider in Hermes' `providers:` map instead of relying on a bare `provider: custom`.

This one was a real bug: Hermes intentionally discards `api_mode: codex_responses` for a plain `custom` provider pointed at a non-OpenAI host (see `hermes_cli/runtime_provider.py::_resolve_plain_custom_api_mode`, a guard against stale config). That silently downgraded the proxy to chat completions and 404'd on every turn. A *named* provider's `transport` is honoured verbatim, which is the supported opt-in. `inspect_hermes_config()` now accepts either wiring so `skillclaw doctor hermes` doesn't report a false negative.

**`evolve_server/core/config.py`** — let `EVOLVE_LLM_BASE_URL` / `OPENAI_BASE_URL` (and the API-key equivalents) override the inherited SkillClaw upstream. Under `codex_oauth` the inherited key is empty by design, so the evolve server needs to be pointed at the SkillClaw proxy to borrow its OAuth handshake.

**`skillclaw/setup_wizard.py`** — adds the provider preset, defaults it to `responses` api_mode, and skips the API-key prompt for it.

## Usage

```bash
skillclaw setup          # choose provider: codex_oauth (no API key prompt)
skillclaw start --daemon
```

Requires an existing ChatGPT login via `hermes auth` or `codex`.

To also run the evolve server on the same credentials:

```bash
EVOLVE_LLM_BASE_URL=http://127.0.0.1:30000/v1 \
EVOLVE_LLM_API_KEY=skillclaw \
EVOLVE_MODEL=skillclaw-model \
skillclaw-evolve-server --use-skillclaw-config --local-root ~/.skillclaw/local-share
```

## Test plan

**29 new unit tests** in `tests/test_codex_oauth.py`, all passing:

- JWT parsing, including tolerance of malformed/empty/non-string tokens (a bad token must surface as an upstream 401, never a crash at request time)
- Expiry and skew behaviour, including that a token with no parseable `exp` is treated as valid so the single-use refresh token isn't burned needlessly
- Base-URL matching — rejects lookalike hosts (`chatgpt.com.attacker.test`), path-segment spoofs, and `http://` downgrades
- Store precedence (later `exp` wins), dual write-back, `credential_pool` alias updates vs. independent accounts left alone
- Header construction, including omitting `ChatGPT-Account-ID` when the claim is absent

**Manually verified end-to-end** on Linux with a ChatGPT Plus account:

- Direct call to `/backend-api/codex/responses` → HTTP 200, streamed response
- Through the proxy → 200, skills injected into `instructions`, session captured
- Full Hermes turn (`hermes chat -m skillclaw-model`) → correct reply, `POST /v1/responses 200 OK`
- `skillclaw doctor hermes` → `status: ok`
- Chat bridge with an evolve-server-shaped request (system prompt + `temperature` + `max_tokens`) → 200
- A complete evolve cycle → `had_processing_error: false`, 3 sessions judged
- Both auth stores verified structurally intact afterward

**Lint:** `ruff check` and `ruff format --check` clean at the pinned CI version (0.12.2).

**Pre-existing failures unrelated to this change:** `tests/test_responses_native.py` sits at 11 failed / 2 passed, and `tests/test_embedding_api.py` fails to collect (`ModuleNotFoundError: numpy`). I confirmed both are identical on unmodified `main` via a `git stash` A/B, so neither is a regression from this PR.

## Notes

- Entirely opt-in. No behavior changes for any existing provider — the static-key path is untouched.
- Rate limits are the subscription's, shared with whatever else uses that ChatGPT account.
- Only OpenAI's official Codex host is treated as such; custom proxies fall through to normal handling.
